### PR TITLE
feat: add PORT environment variable support to backend

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -39,7 +39,7 @@ USER appuser
 EXPOSE 8000
 
 # Default command (overridden by docker-compose)
-CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+CMD ["sh", "-c", "uvicorn src.main:app --host 0.0.0.0 --port ${PORT:-8000} --reload"]
 
 # Production stage
 FROM base as production
@@ -63,7 +63,7 @@ EXPOSE 8000
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:8000/health || exit 1
+    CMD curl -f http://localhost:${PORT:-8000}/health || exit 1
 
 # Production command
-CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "4"]
+CMD ["sh", "-c", "uvicorn src.main:app --host 0.0.0.0 --port ${PORT:-8000} --workers 4"]

--- a/backend/src/infrastructure/config.py
+++ b/backend/src/infrastructure/config.py
@@ -43,6 +43,13 @@ class Settings(BaseSettings):
         description="Ambiente de execução (development, staging, production)",
     )
 
+    # Server settings
+    port: int = Field(
+        default=8000,
+        description="Porta do servidor",
+        validation_alias="PORT",
+    )
+
     # API settings
     api_v1_prefix: str = Field(
         default="/api/v1",

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -149,7 +149,7 @@ if __name__ == "__main__":
     uvicorn.run(
         "src.main:app",
         host="0.0.0.0",
-        port=8000,
+        port=settings.port,
         reload=True,
         log_level=settings.log_level.lower(),
     )


### PR DESCRIPTION
## Summary
- Adiciona suporte à variável de ambiente PORT no backend
- Permite configuração dinâmica da porta do servidor
- Mantém compatibilidade com porta padrão 8000

## Alterações Realizadas
- **config.py**: Novo campo `port` com validação da variável `PORT`
- **main.py**: Atualizado para usar `settings.port` em vez de porta hardcoded
- **Dockerfile**: Comandos modificados para usar `${PORT:-8000}` 
- **Health Check**: Ajustado para usar porta dinâmica

## Requisitos Atendidos
✅ Start script claro  
✅ Variável PORT definida  
✅ Health check (/health)  
✅ Dockerfile completo  

## Teste
```bash
# Teste com porta padrão
docker run -p 8000:8000 backend

# Teste com porta customizada
docker run -e PORT=3000 -p 3000:3000 backend
```

🤖 Generated with [Claude Code](https://claude.ai/code)