### PR TITLE
fix: configure nginx MIME types for JavaScript ES6 modules

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -5,6 +5,19 @@ server {
     root /usr/share/nginx/html;
     index index.html index.htm;
     
+    # MIME types for JavaScript modules
+    location ~* \.js$ {
+        add_header Content-Type application/javascript;
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+    
+    location ~* \.mjs$ {
+        add_header Content-Type application/javascript;
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+    
     # Handle React Router (client-side routing)
     location / {
         try_files $uri $uri/ /index.html;
@@ -19,8 +32,8 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
     
-    # Static files caching
-    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
+    # Static files caching (excluding js files which are handled above)
+    location ~* \.(css|png|jpg|jpeg|gif|ico|svg)$ {
         expires 1y;
         add_header Cache-Control "public, immutable";
     }


### PR DESCRIPTION
## Summary
• Fixes nginx configuration to serve JavaScript files with correct MIME type
• Resolves "Expected a JavaScript module script but got application/octet-stream" error in Coolify deployment
• Adds specific location blocks for .js and .mjs files with proper application/javascript MIME type

## Test plan
- [x] Deploy to Coolify and verify JavaScript modules load correctly
- [x] Confirm no more MIME type errors in browser console
- [x] Verify React app loads properly

🤖 Generated with [Claude Code](https://claude.ai/code)