### PR TITLE
Make sidebar navigation collapsible

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,6 +21,7 @@ const queryClient = new QueryClient({
 
 function Shell() {
   const [activeTab, setActiveTab] = useState('dashboard');
+  const [isNavigationCollapsed, setIsNavigationCollapsed] = useState(false);
   const renderContent = () => {
     switch (activeTab) {
       case 'dashboard':
@@ -39,8 +40,13 @@ function Shell() {
   };
   return (
     <div className="min-h-screen bg-gray-50 flex">
-      <Navigation activeTab={activeTab} onTabChange={setActiveTab} />
-      <main className="flex-1 p-8">{renderContent()}</main>
+      <Navigation
+        activeTab={activeTab}
+        onTabChange={setActiveTab}
+        isCollapsed={isNavigationCollapsed}
+        onToggleCollapse={() => setIsNavigationCollapsed((previous) => !previous)}
+      />
+      <main className="flex-1 p-8 transition-all duration-300">{renderContent()}</main>
     </div>
   );
 }

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -1,14 +1,18 @@
 import {
-    CalendarDaysIcon,
-    HomeIcon,
-    TruckIcon,
-    UserIcon,
+  CalendarDaysIcon,
+  ChevronDoubleLeftIcon,
+  ChevronDoubleRightIcon,
+  HomeIcon,
+  TruckIcon,
+  UserIcon,
 } from '@heroicons/react/24/outline';
 import React from 'react';
 
 interface NavigationProps {
   activeTab: string;
   onTabChange: (tab: string) => void;
+  isCollapsed: boolean;
+  onToggleCollapse: () => void;
 }
 
 const navigationItems = [
@@ -44,45 +48,97 @@ const navigationItems = [
   },
 ];
 
-export const Navigation: React.FC<NavigationProps> = ({ activeTab, onTabChange }) => {
+export const Navigation: React.FC<NavigationProps> = ({
+  activeTab,
+  onTabChange,
+  isCollapsed,
+  onToggleCollapse,
+}) => {
   return (
-    <nav className="bg-white shadow-sm border-r border-gray-200 w-64 min-h-screen">
-      <div className="p-6">
-        <div className="flex items-center space-x-2 mb-8">
-          <UserIcon className="w-8 h-8 text-blue-600" />
-          <h1 className="text-xl font-bold text-gray-900">
-            Sistema de Agendamentos
-          </h1>
+    <nav
+      className={`bg-white shadow-sm border-r border-gray-200 min-h-screen flex flex-col transition-all duration-300 ${
+        isCollapsed ? 'w-16' : 'w-64'
+      }`}
+    >
+      <div
+        className={`border-b border-gray-100 flex flex-col gap-6 ${
+          isCollapsed ? 'px-2 py-4' : 'px-6 py-6'
+        }`}
+      >
+        <button
+          type="button"
+          onClick={onToggleCollapse}
+          className="self-end p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-md transition-colors"
+          aria-label={isCollapsed ? 'Expandir menu lateral' : 'Recolher menu lateral'}
+          aria-expanded={!isCollapsed}
+        >
+          {isCollapsed ? (
+            <ChevronDoubleRightIcon className="w-5 h-5" />
+          ) : (
+            <ChevronDoubleLeftIcon className="w-5 h-5" />
+          )}
+        </button>
+        <div
+          className={`flex items-center ${
+            isCollapsed ? 'justify-center' : 'space-x-2'
+          }`}
+        >
+          <UserIcon
+            className={`text-blue-600 ${isCollapsed ? 'w-7 h-7' : 'w-8 h-8'}`}
+          />
+          {!isCollapsed && (
+            <h1 className="text-xl font-bold text-gray-900">
+              Sistema de Agendamentos
+            </h1>
+          )}
         </div>
+      </div>
 
-        <div className="space-y-2">
-          {navigationItems.map((item) => {
-            const Icon = item.icon;
-            const isActive = activeTab === item.id;
-            
-            return (
-              <button
-                key={item.id}
-                onClick={() => onTabChange(item.id)}
-                className={`w-full flex items-center space-x-3 px-4 py-3 rounded-lg text-left transition-colors duration-200 ${
-                  isActive
-                    ? 'bg-blue-50 text-blue-700 border-l-4 border-blue-600'
-                    : 'text-gray-700 hover:bg-gray-50'
-                }`}
-              >
-                <Icon className={`w-5 h-5 ${isActive ? 'text-blue-600' : 'text-gray-400'}`} />
+      <div className={`flex-1 ${isCollapsed ? 'px-2' : 'px-4'} py-4 space-y-2`}>
+        {navigationItems.map((item) => {
+          const Icon = item.icon;
+          const isActive = activeTab === item.id;
+          const buttonClasses = `w-full flex items-center px-3 py-3 rounded-lg transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
+            isCollapsed ? 'justify-center' : 'space-x-3 text-left'
+          } ${
+            isActive
+              ? `bg-blue-50 text-blue-700 ${
+                  isCollapsed ? '' : 'border-l-4 border-blue-600'
+                }`
+              : 'text-gray-700 hover:bg-gray-50'
+          }`;
+
+          return (
+            <button
+              type="button"
+              key={item.id}
+              onClick={() => onTabChange(item.id)}
+              className={buttonClasses}
+            >
+              <Icon
+                className={`w-5 h-5 ${isActive ? 'text-blue-600' : 'text-gray-400'}`}
+              />
+              {!isCollapsed && (
                 <div>
-                  <p className={`font-medium ${isActive ? 'text-blue-900' : 'text-gray-900'}`}>
+                  <p
+                    className={`font-medium ${
+                      isActive ? 'text-blue-900' : 'text-gray-900'
+                    }`}
+                  >
                     {item.name}
                   </p>
-                  <p className={`text-xs ${isActive ? 'text-blue-600' : 'text-gray-500'}`}>
+                  <p
+                    className={`text-xs ${
+                      isActive ? 'text-blue-600' : 'text-gray-500'
+                    }`}
+                  >
                     {item.description}
                   </p>
                 </div>
-              </button>
-            );
-          })}
-        </div>
+              )}
+            </button>
+          );
+        })}
       </div>
     </nav>
   );


### PR DESCRIPTION
## Summary
- add a collapsible navigation state to the application shell
- update the sidebar to toggle between compact and expanded layouts with icon-only mode

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cedca1dde48323bfd5882ec28d61ba