### PR TITLE
feat: allow manual appointment creation

### DIFF
--- a/PROGRESS_AGENDAMENTOS.md
+++ b/PROGRESS_AGENDAMENTOS.md
@@ -13,6 +13,8 @@
 - [x] A11y (focus, ESC, aria, tab trap)
 - [x] Testes smoke/interação (abrir modal, trocar views, aplicar filtro)
 - [x] Atualização do PROGRESS_AGENDAMENTOS.md com evidências
+- [x] Botão “Adicionar Agendamento” + modal de cadastro manual
+- [x] Integração `POST /appointments` com invalidação de cache e toasts de feedback
 
 ## Arquitetura & Convenções (anotações iniciais)
 - Frontend em React + Vite, TypeScript, TailwindCSS; estado remoto via TanStack Query; formulários e componentes com Heroicons.
@@ -34,6 +36,9 @@
 - Adaptador `toAppointmentViewModel` criado para mascarar CPF e montar rótulo do plano com campos existentes.
 - Toggle ampliado para incluir visualização em tabela, mantendo calendário/agenda originais.
 - Modal agora usa `Modal` do design system com trap de foco; revisar contrastes e aria após testes.
+- Novo modal de criação manual reaproveita listas existentes; telefonemas normalizados no client antes do envio.
+- Toasts globais (`useToast`) adotados para padronizar feedback de upload e criação manual.
+- Validação reforçada: telefone passa a ser obrigatório no fluxo manual (frontend + API) com exigência de 10 ou 11 dígitos.
 - Testes automatizados rodam via `npm test` usando `esbuild` + `node:test` (sem dependências extras).
 - Pendente: registrar evidências finais (prints/resultados) e capturar status do lint com falsos positivos herdados.
 - Layout ajustado para botões/atalhos arredondados, KPIs minimalistas e tabela mais próxima do mock fornecido.
@@ -45,6 +50,7 @@
 4. Usar busca por nome/CPF → lista/cards filtram localmente.
 5. Alternar entre Cards ↔ Lista ↔ outras visualizações existentes → campos de CPF/Plano visíveis.
 6. Validar acessibilidade: fechar modal com ESC, foco contido no modal e restaurado ao fechar.
+7. Abrir modal "Adicionar Agendamento", preencher campos mínimos e salvar → novo registro deve aparecer na listagem/cards e toasts devem indicar o resultado.
 
 ## Notas de Acessibilidade
 - Garantir foco inicial no primeiro elemento interativo do modal e trap de tab até o fechamento.
@@ -56,5 +62,5 @@
 - PR: _pendente_
 - Commits: _pendente_
 - Capturas: _pendente_
-- Testes: `npm test` (ok - smoke suite)
+- Testes: `PYTEST_ADDOPTS="--no-cov" pytest backend/tests/test_appointment_service.py backend/tests/test_appointment_api.py` (ok) e `npm test` (ok - smoke suite)
 - Lint: `npm run lint` (falhou em pendências pré-existentes fora do escopo desta feature)

--- a/backend/tests/test_appointment_api.py
+++ b/backend/tests/test_appointment_api.py
@@ -1,0 +1,135 @@
+"""API tests for appointment endpoints."""
+
+from datetime import datetime
+from uuid import uuid4
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.application.dtos.appointment_dto import AppointmentResponseDTO
+from src.main import app
+from src.presentation.api.v1.endpoints.appointments import (
+    get_appointment_service,
+)
+
+
+@pytest.fixture
+def client() -> TestClient:
+    """Create test client for API interactions."""
+    return TestClient(app)
+
+
+def _build_response_dto() -> AppointmentResponseDTO:
+    """Helper to create a response DTO with default values."""
+    return AppointmentResponseDTO(
+        id=uuid4(),
+        nome_marca="Marca",
+        nome_unidade="Unidade",
+        nome_paciente="Paciente",
+        data_agendamento=datetime(2025, 1, 10, 9, 0),
+        hora_agendamento="09:00",
+        tipo_consulta=None,
+        status="Confirmado",
+        telefone="11999988888",
+        carro=None,
+        observacoes=None,
+        driver_id=None,
+        collector_id=None,
+        cep=None,
+        endereco_coleta=None,
+        endereco_completo=None,
+        endereco_normalizado=None,
+        documento_completo=None,
+        documento_normalizado=None,
+        cpf=None,
+        rg=None,
+        numero_convenio=None,
+        nome_convenio=None,
+        carteira_convenio=None,
+        created_at=datetime(2025, 1, 10, 9, 0),
+        updated_at=None,
+    )
+
+
+def test_create_appointment_success(client: TestClient) -> None:
+    """Endpoint should create appointment and return 201."""
+    payload = {
+        "nome_marca": "Marca",
+        "nome_unidade": "Unidade",
+        "nome_paciente": "Paciente",
+        "data_agendamento": "2025-01-10T09:00:00",
+        "hora_agendamento": "09:00",
+        "status": "Confirmado",
+        "telefone": "11999988888",
+    }
+
+    service_mock = MagicMock()
+    service_mock.create_appointment = AsyncMock(
+        return_value={
+            "success": True,
+            "message": "Agendamento criado com sucesso",
+            "appointment": _build_response_dto(),
+        }
+    )
+
+    async def override_service() -> MagicMock:
+        return service_mock
+
+    app.dependency_overrides[get_appointment_service] = override_service
+    try:
+        response = client.post("/api/v1/appointments/", json=payload)
+    finally:
+        app.dependency_overrides.pop(get_appointment_service, None)
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["success"] is True
+    assert data["data"]["nome_paciente"] == "Paciente"
+    assert data["message"] == "Agendamento criado com sucesso"
+
+
+@pytest.mark.parametrize(
+    "error_code,status_code",
+    [
+        ("duplicate", 409),
+        ("validation", 400),
+        ("internal", 500),
+    ],
+)
+def test_create_appointment_error_responses(
+    client: TestClient, error_code: str, status_code: int
+) -> None:
+    """Endpoint should map service error codes to HTTP status."""
+    payload = {
+        "nome_marca": "Marca",
+        "nome_unidade": "Unidade",
+        "nome_paciente": "Paciente",
+        "data_agendamento": "2025-01-10T09:00:00",
+        "hora_agendamento": "09:00",
+        "status": "Confirmado",
+        "telefone": "11999988888",
+    }
+
+    service_mock = MagicMock()
+    service_mock.create_appointment = AsyncMock(
+        return_value={
+            "success": False,
+            "message": "Erro",
+            "error_code": error_code,
+        }
+    )
+
+    async def override_service() -> MagicMock:
+        return service_mock
+
+    app.dependency_overrides[get_appointment_service] = override_service
+    try:
+        response = client.post("/api/v1/appointments/", json=payload)
+    finally:
+        app.dependency_overrides.pop(get_appointment_service, None)
+
+    assert response.status_code == status_code
+    body = response.json()
+    assert body["success"] is False
+    assert body["message"] == "Erro"

--- a/backend/tests/test_appointment_service.py
+++ b/backend/tests/test_appointment_service.py
@@ -1,0 +1,145 @@
+"""Tests for appointment service business logic."""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.application.dtos.appointment_dto import AppointmentCreateDTO
+from src.application.services.appointment_service import AppointmentService
+from src.domain.entities.appointment import Appointment
+
+
+@pytest.mark.asyncio
+async def test_create_appointment_success() -> None:
+    """Service should persist appointment when no duplicate exists."""
+    repository = MagicMock()
+    created_entity = Appointment(
+        nome_marca="Marca",
+        nome_unidade="Unidade",
+        nome_paciente="Paciente",
+        data_agendamento=datetime(2025, 1, 10, 9, 0),
+        hora_agendamento="09:00",
+        status="Confirmado",
+        telefone="11999988888",
+    )
+    repository.find_duplicates = AsyncMock(return_value=[])
+    repository.create = AsyncMock(return_value=created_entity)
+
+    service = AppointmentService(repository, excel_parser=MagicMock())
+
+    dto = AppointmentCreateDTO(
+        nome_marca="Marca",
+        nome_unidade="Unidade",
+        nome_paciente="Paciente",
+        data_agendamento=datetime(2025, 1, 10, 9, 0),
+        hora_agendamento="09:00",
+        status="Confirmado",
+        telefone="11999988888",
+    )
+
+    result = await service.create_appointment(dto)
+
+    assert result["success"] is True
+    assert result["appointment"].nome_paciente == "Paciente"
+    repository.create.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_create_appointment_duplicate() -> None:
+    """Service should prevent duplicated appointments."""
+    repository = MagicMock()
+    repository.find_duplicates = AsyncMock(return_value=["existing-id"])
+    repository.create = AsyncMock()
+
+    service = AppointmentService(repository, excel_parser=MagicMock())
+
+    dto = AppointmentCreateDTO(
+        nome_marca="Marca",
+        nome_unidade="Unidade",
+        nome_paciente="Paciente",
+        data_agendamento=datetime(2025, 1, 10, 9, 0),
+        hora_agendamento="09:00",
+        status="Confirmado",
+        telefone="11999988888",
+    )
+
+    result = await service.create_appointment(dto)
+
+    assert result["success"] is False
+    assert result["error_code"] == "duplicate"
+    repository.create.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_appointment_validation_error() -> None:
+    """Invalid domain data should surface as validation error."""
+    repository = MagicMock()
+    repository.find_duplicates = AsyncMock()
+
+    service = AppointmentService(repository, excel_parser=MagicMock())
+
+    dto = AppointmentCreateDTO(
+        nome_marca="Marca",
+        nome_unidade="Unidade",
+        nome_paciente="Paciente",
+        data_agendamento=datetime(2025, 1, 10, 9, 0),
+        hora_agendamento="09:00",
+        status="Status-Invalido",
+        telefone="11999988888",
+    )
+
+    result = await service.create_appointment(dto)
+
+    assert result["success"] is False
+    assert result["error_code"] == "validation"
+    repository.find_duplicates.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_appointment_internal_error() -> None:
+    """Unexpected errors should be captured as internal failures."""
+    repository = MagicMock()
+    repository.find_duplicates = AsyncMock(return_value=[])
+    repository.create = AsyncMock(side_effect=RuntimeError("DB down"))
+
+    service = AppointmentService(repository, excel_parser=MagicMock())
+
+    dto = AppointmentCreateDTO(
+        nome_marca="Marca",
+        nome_unidade="Unidade",
+        nome_paciente="Paciente",
+        data_agendamento=datetime(2025, 1, 10, 9, 0),
+        hora_agendamento="09:00",
+        status="Confirmado",
+        telefone="11999988888",
+    )
+
+    result = await service.create_appointment(dto)
+
+    assert result["success"] is False
+    assert result["error_code"] == "internal"
+
+
+@pytest.mark.asyncio
+async def test_create_appointment_missing_phone() -> None:
+    """Missing phone should trigger validation error."""
+    repository = MagicMock()
+    repository.find_duplicates = AsyncMock()
+
+    service = AppointmentService(repository, excel_parser=MagicMock())
+
+    dto = AppointmentCreateDTO(
+        nome_marca="Marca",
+        nome_unidade="Unidade",
+        nome_paciente="Paciente",
+        data_agendamento=datetime(2025, 1, 10, 9, 0),
+        hora_agendamento="09:00",
+        status="Confirmado",
+    )
+
+    result = await service.create_appointment(dto)
+
+    assert result["success"] is False
+    assert result["error_code"] == "validation"
+    repository.find_duplicates.assert_not_called()

--- a/docs/APPOINTMENT_IMPLEMENTATION_GUIDE.md
+++ b/docs/APPOINTMENT_IMPLEMENTATION_GUIDE.md
@@ -584,3 +584,13 @@ export const formatDateTime = (dateString: string, timeString: string) => {
 ---
 
 **🎯 Resultado:** Interface moderna, responsiva e user-friendly para gestão de agendamentos.
+
+---
+
+## ✏️ Cadastro Manual de Agendamentos (2025)
+
+- Botão "Adicionar Agendamento" disponível no header da página principal abre modal com componente `Modal` do design system (focus trap, ESC, scroll lock).
+- Formulário consome listas já expostas pela API (`filter-options`, `drivers/active`, `collectors/active`) e aplica validações client-side alinhadas ao backend (campos obrigatórios, horário HH:MM, telefone com 10-11 dígitos).
+- Submissão aciona `appointmentAPI.createAppointment` (`POST /api/v1/appointments`) e, em caso de sucesso, invalida caches de `appointments`, `filterOptions` e `dashboardStats` via TanStack Query para refletir o novo registro.
+- Feedback visual unificado via `useToast` (sucesso/erro) e fechamento automático do modal; mensagens de conflito (409) retornadas pelo backend são exibidas diretamente ao usuário.
+- Modal organizado por seções: dados principais, contato, logística (motorista/coletora), convênio e observações, mantendo consistência com o modelo importado da planilha.

--- a/docs/APPOINTMENT_MANUAL_CREATION_PLAN.md
+++ b/docs/APPOINTMENT_MANUAL_CREATION_PLAN.md
@@ -1,0 +1,49 @@
+# Plano de Implementação — Criação Manual de Agendamentos
+
+## Objetivo
+- Permitir que usuários cadastrem agendamentos manualmente via interface web, mantendo consistência com os dados importados via planilha e garantindo validações de negócio já adotadas.
+
+## Etapas Propostas
+
+1. **Alinhamento e Descoberta**
+   - Revisar com o time o fluxo desejado (quem pode criar, permissões futuras, comportamento esperado do status inicial).
+   - Mapear todos os campos obrigatórios e opcionais utilizados hoje (`nome_marca`, `nome_unidade`, `nome_paciente`, `data_agendamento`, `hora_agendamento`, `tipo_consulta`, `status`, `telefone`, `carro`, `observacoes`, `driver_id`, `collector_id`, `numero_convenio`, `nome_convenio`, `carteira_convenio`).
+   - Validar valores permitidos para status (lista definida na entidade `Appointment`) e quais opções devem aparecer no formulário.
+   - Identificar fontes de dados para selects (`filterOptions`, `activeDrivers`, `activeCollectors`) e se campos como unidades/marcas precisam de auto completar ou lista fixa.
+
+2. **Backend — Caso de Uso e Endpoint**
+   - Adicionar método dedicado em `AppointmentService` para criar um agendamento único reutilizando validações da entidade (`Appointment`) e garantindo normalização (hora, telefone, status).
+   - Garantir que o repositório Mongo implemente `create` para persitir um único registro (confirmar contrato atual e ajustar se necessário).
+   - Expor rota `POST /appointments` em `appointments.py` utilizando `AppointmentCreateDTO` como input e `AppointmentResponseDTO` como output; incluir tratamento de erros amigáveis (400 para validações, 409 para duplicados, 500 para falhas internas).
+   - Revisar dependências (injeção com `get_appointment_service`) e adicionar logs/metadados relevantes.
+   - Cobrir com testes `pytest`: unidade do serviço (happy path, validação de status/hora/telefone) e teste de integração do endpoint simulando o fluxo completo.
+
+3. **Frontend — Camada de Dados**
+   - Criar tipo `AppointmentCreateRequest` espelhando `AppointmentCreateDTO` e avaliar defaults (ex.: `status` = `Confirmado`).
+   - Estender `appointmentAPI` com método `createAppointment` (`POST /appointments`) e definir invalidações necessárias no `react-query` (`appointments`, `filterOptions`, `dashboardStats`).
+   - Centralizar helpers de status/opções em `utils/appointmentViewModel` ou criar util dedicado para evitar duplicação entre formulário e filtros.
+   - Garantir tratamento de erros da API com mensagens amigáveis e feedback consistente (toast/alerta).
+
+4. **Frontend — UI/UX**
+   - Adicionar botão "Adicionar Agendamento" no header da `AppointmentsPage`, ao lado do upload, considerando estados responsivos (mobile/desktop).
+   - Implementar modal de formulário reutilizando padrões existentes (ver `PublicRegister` para referência de formulários com `react-hook-form` ou padrão usado no projeto).
+   - Estruturar o formulário em seções lógicas: Dados principais, Contato, Logística (motorista/coletora/carro), Convênio, Observações.
+   - Aplicar validações client-side alinhadas com o backend (formatos de data/hora, telefone, obrigatoriedade) e máscaras onde fizer sentido.
+   - Preencher selects com dados vindos de `filterOptions`, `driversData`, `collectorsData`; considerar autocomplete para evitar listas extensas.
+   - Exibir estado de loading enquanto a submissão é processada e fechar a modal automaticamente ao sucesso.
+
+5. **Integração e Fluxo**
+   - Após criação bem-sucedida, atualizar a listagem atual respeitando filtros ativos (usar `invalidateQueries` ou atualizar cache manualmente para experiência imediata).
+   - Garantir que novas entradas apareçam corretamente em todas as visualizações (`cards`, `table`, `calendar`, `agenda`).
+   - Atualizar KPIs e demais dashboards dependentes (invalidar queries relevantes ou atualizar dados localmente).
+
+6. **Testes Frontend e QA**
+   - Implementar testes unitários do formulário (validações, campos obrigatórios) utilizando React Testing Library.
+   - Acrescentar testes de integração e2e (quando prático) cobrindo criação manual e exibição nas principais visualizações.
+   - Realizar QA manual: cenários com campos mínimos, com dados completos, tratamento de erros da API, compatibilidade mobile.
+
+7. **Documentação e Handoff**
+   - Atualizar `docs/` com instruções de uso da nova funcionalidade (incluindo pré-requisitos e mensagens de erro comuns).
+   - Registrar alterações relevantes no changelog/PROGRESS_AGENDAMENTOS.md e alinhar com o time de suporte/operacional.
+   - Preparar passo-a-passo de validação pós-deploy (monitoramento de logs, métricas de criação manual, rollback plan).
+

--- a/frontend/src/components/AppointmentFormModal.tsx
+++ b/frontend/src/components/AppointmentFormModal.tsx
@@ -1,0 +1,405 @@
+import { useEffect, useMemo } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+
+import { Modal } from './ui/Modal';
+import type { AppointmentCreateRequest } from '../types/appointment';
+import type { ActiveDriver } from '../types/driver';
+import type { ActiveCollector } from '../types/collector';
+import { APPOINTMENT_STATUS_OPTIONS } from '../utils/appointmentViewModel';
+
+interface AppointmentFormModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (data: AppointmentCreateRequest) => Promise<void> | void;
+  isSubmitting?: boolean;
+  brands: string[];
+  units: string[];
+  statuses?: string[];
+  drivers: ActiveDriver[];
+  collectors: ActiveCollector[];
+}
+
+type FormValues = {
+  nome_marca: string;
+  nome_unidade: string;
+  nome_paciente: string;
+  date: string;
+  time: string;
+  tipo_consulta: string;
+  status: string;
+  telefone: string;
+  carro: string;
+  observacoes: string;
+  driver_id: string;
+  collector_id: string;
+  numero_convenio: string;
+  nome_convenio: string;
+  carteira_convenio: string;
+};
+
+const formSchema = z.object({
+  nome_marca: z.string().trim().min(1, 'Informe a marca/clinica'),
+  nome_unidade: z.string().trim().min(1, 'Informe a unidade'),
+  nome_paciente: z.string().trim().min(1, 'Informe o nome do paciente'),
+  date: z.string().trim().min(1, 'Selecione a data do agendamento'),
+  time: z
+    .string()
+    .trim()
+    .regex(/^([01]\d|2[0-3]):[0-5]\d$/, 'Hora inválida (use HH:MM)'),
+  tipo_consulta: z.string().trim().optional().default(''),
+  status: z.string().trim().min(1, 'Selecione o status'),
+  telefone: z
+    .string()
+    .trim()
+    .min(1, 'Informe o telefone do paciente')
+    .refine((value) => {
+      const digits = value.replace(/\D/g, '');
+      return digits.length === 10 || digits.length === 11;
+    }, 'Telefone deve conter 10 ou 11 dígitos'),
+  carro: z.string().trim().optional().default(''),
+  observacoes: z.string().trim().optional().default(''),
+  driver_id: z.string().trim().optional().default(''),
+  collector_id: z.string().trim().optional().default(''),
+  numero_convenio: z.string().trim().optional().default(''),
+  nome_convenio: z.string().trim().optional().default(''),
+  carteira_convenio: z.string().trim().optional().default(''),
+});
+
+export function AppointmentFormModal({
+  isOpen,
+  onClose,
+  onSubmit,
+  isSubmitting = false,
+  brands,
+  units,
+  statuses,
+  drivers,
+  collectors,
+}: AppointmentFormModalProps) {
+  const statusChoices = useMemo(
+    () => (statuses && statuses.length > 0 ? statuses : [...APPOINTMENT_STATUS_OPTIONS]),
+    [statuses]
+  );
+
+  const defaultStatus = useMemo(() => {
+    if (statusChoices.includes('Confirmado')) {
+      return 'Confirmado';
+    }
+    if (statusChoices.includes('Agendado')) {
+      return 'Agendado';
+    }
+    return statusChoices[0] ?? 'Pendente';
+  }, [statusChoices]);
+
+  const defaultValues = useMemo<FormValues>(
+    () => ({
+      nome_marca: '',
+      nome_unidade: '',
+      nome_paciente: '',
+      date: '',
+      time: '',
+      tipo_consulta: '',
+      status: defaultStatus,
+      telefone: '',
+      carro: '',
+      observacoes: '',
+      driver_id: '',
+      collector_id: '',
+      numero_convenio: '',
+      nome_convenio: '',
+      carteira_convenio: '',
+    }),
+    [defaultStatus]
+  );
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues,
+  });
+
+  useEffect(() => {
+    if (isOpen) {
+      reset(defaultValues);
+    }
+  }, [isOpen, reset, defaultValues]);
+
+  const handleClose = () => {
+    reset(defaultValues);
+    onClose();
+  };
+
+  const onSubmitForm = (values: FormValues) => {
+    const iso = new Date(`${values.date}T${values.time}:00`);
+    if (Number.isNaN(iso.getTime())) {
+      return;
+    }
+
+    const phoneDigits = values.telefone.replace(/\D/g, '');
+
+    const payload: AppointmentCreateRequest = {
+      nome_marca: values.nome_marca.trim(),
+      nome_unidade: values.nome_unidade.trim(),
+      nome_paciente: values.nome_paciente.trim(),
+      data_agendamento: iso.toISOString(),
+      hora_agendamento: values.time,
+      tipo_consulta: values.tipo_consulta.trim() || undefined,
+      status: values.status,
+      telefone: phoneDigits,
+      carro: values.carro.trim() || undefined,
+      observacoes: values.observacoes.trim() || undefined,
+      driver_id: values.driver_id || undefined,
+      collector_id: values.collector_id || undefined,
+      numero_convenio: values.numero_convenio.trim() || undefined,
+      nome_convenio: values.nome_convenio.trim() || undefined,
+      carteira_convenio: values.carteira_convenio.trim() || undefined,
+    };
+
+    onSubmit(payload);
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={handleClose}
+      title="Adicionar Agendamento"
+      size="xl"
+    >
+      <form className="space-y-6" onSubmit={handleSubmit(onSubmitForm)}>
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Marca / Clínica *</label>
+            <input
+              type="text"
+              {...register('nome_marca')}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+              list="appointment-brand-options"
+              placeholder="Clínica Saúde"
+              disabled={isSubmitting}
+            />
+            <datalist id="appointment-brand-options">
+              {brands.map((brand) => (
+                <option key={brand} value={brand} />
+              ))}
+            </datalist>
+            {errors.nome_marca && (
+              <p className="mt-1 text-sm text-red-600">{errors.nome_marca.message}</p>
+            )}
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Unidade *</label>
+            <input
+              type="text"
+              {...register('nome_unidade')}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+              list="appointment-unit-options"
+              placeholder="Unidade Centro"
+              disabled={isSubmitting}
+            />
+            <datalist id="appointment-unit-options">
+              {units.map((unit) => (
+                <option key={unit} value={unit} />
+              ))}
+            </datalist>
+            {errors.nome_unidade && (
+              <p className="mt-1 text-sm text-red-600">{errors.nome_unidade.message}</p>
+            )}
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Nome do paciente *</label>
+            <input
+              type="text"
+              {...register('nome_paciente')}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+              placeholder="Maria da Silva"
+              disabled={isSubmitting}
+            />
+            {errors.nome_paciente && (
+              <p className="mt-1 text-sm text-red-600">{errors.nome_paciente.message}</p>
+            )}
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Tipo de consulta</label>
+            <input
+              type="text"
+              {...register('tipo_consulta')}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+              placeholder="Ex.: Coleta domiciliar"
+              disabled={isSubmitting}
+            />
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Data *</label>
+            <input
+              type="date"
+              {...register('date')}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+              disabled={isSubmitting}
+            />
+            {errors.date && (
+              <p className="mt-1 text-sm text-red-600">{errors.date.message}</p>
+            )}
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Hora *</label>
+            <input
+              type="time"
+              {...register('time')}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+              disabled={isSubmitting}
+            />
+            {errors.time && (
+              <p className="mt-1 text-sm text-red-600">{errors.time.message}</p>
+            )}
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Status *</label>
+            <select
+              {...register('status')}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+              disabled={isSubmitting}
+            >
+              {statusChoices.map((status) => (
+                <option key={status} value={status}>
+                  {status}
+                </option>
+              ))}
+            </select>
+            {errors.status && (
+              <p className="mt-1 text-sm text-red-600">{errors.status.message}</p>
+            )}
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Telefone *</label>
+            <input
+              type="tel"
+              {...register('telefone')}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+              placeholder="1199998888"
+              disabled={isSubmitting}
+            />
+            {errors.telefone && (
+              <p className="mt-1 text-sm text-red-600">{errors.telefone.message}</p>
+            )}
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Motorista</label>
+            <select
+              {...register('driver_id')}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+              disabled={isSubmitting}
+            >
+              <option value="">Sem motorista</option>
+              {drivers.map((driver) => (
+                <option key={driver.id} value={driver.id}>
+                  {driver.nome_completo}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Coletora</label>
+            <select
+              {...register('collector_id')}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+              disabled={isSubmitting}
+            >
+              <option value="">Sem coletora</option>
+              {collectors.map((collector) => (
+                <option key={collector.id} value={collector.id}>
+                  {collector.nome_completo}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Carro</label>
+            <input
+              type="text"
+              {...register('carro')}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+              placeholder="Placa ou identificação"
+              disabled={isSubmitting}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Nome do convênio</label>
+            <input
+              type="text"
+              {...register('nome_convenio')}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+              disabled={isSubmitting}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Número do convênio</label>
+            <input
+              type="text"
+              {...register('numero_convenio')}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+              disabled={isSubmitting}
+            />
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+          <div className="md:col-span-1">
+            <label className="block text-sm font-medium text-gray-700">Carteira do convênio</label>
+            <input
+              type="text"
+              {...register('carteira_convenio')}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+              disabled={isSubmitting}
+            />
+          </div>
+          <div className="md:col-span-2">
+            <label className="block text-sm font-medium text-gray-700">Observações</label>
+            <textarea
+              rows={3}
+              {...register('observacoes')}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+              placeholder="Informações adicionais relevantes"
+              disabled={isSubmitting}
+            />
+          </div>
+        </div>
+
+        <div className="flex items-center justify-end gap-3 pt-4 border-t border-gray-200">
+          <button
+            type="button"
+            onClick={handleClose}
+            className="inline-flex justify-center rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+            disabled={isSubmitting}
+          >
+            Cancelar
+          </button>
+          <button
+            type="submit"
+            className="inline-flex justify-center rounded-md border border-transparent px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-60"
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? 'Salvando...' : 'Salvar agendamento'}
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,5 +1,7 @@
 import axios from 'axios';
 import type {
+    AppointmentCreateRequest,
+    AppointmentCreateResponse,
     AppointmentFilter,
     AppointmentListResponse,
     DashboardStats,
@@ -72,11 +74,22 @@ api.interceptors.response.use(
 );
 
 export const appointmentAPI = {
+  // Create appointment manually
+  createAppointment: async (
+    payload: AppointmentCreateRequest
+  ): Promise<AppointmentCreateResponse> => {
+    const response = await api.post<AppointmentCreateResponse>(
+      '/appointments',
+      payload
+    );
+    return response.data;
+  },
+
   // Upload Excel file
   uploadExcel: async (file: File, replaceExisting = false): Promise<ExcelUploadResponse> => {
     const formData = new FormData();
     formData.append('file', file);
-    
+
     const response = await api.post<ExcelUploadResponse>(
       `/appointments/upload?replace_existing=${replaceExisting}`,
       formData,

--- a/frontend/src/tests/smoke/appointments.test.tsx
+++ b/frontend/src/tests/smoke/appointments.test.tsx
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto';
 import { describe, test } from 'node:test';
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
+import { AppointmentFormModal } from '../../components/AppointmentFormModal';
 import { Modal } from '../../components/ui/Modal';
 import { ViewModeToggle } from '../../components/ViewModeToggle';
 import {
@@ -60,6 +61,25 @@ describe('Appointments smoke tests', () => {
 
     assert.ok(markup.includes('Lista'));
     assert.ok(markup.includes('aria-pressed="true"'));
+  });
+
+  test('AppointmentFormModal renders required inputs when opened', () => {
+    const markup = renderToStaticMarkup(
+      <AppointmentFormModal
+        isOpen
+        onClose={() => undefined}
+        onSubmit={async () => undefined}
+        brands={['Marca X']}
+        units={['Unidade Centro']}
+        statuses={['Confirmado', 'Pendente']}
+        drivers={[]}
+        collectors={[]}
+      />
+    );
+
+    assert.ok(markup.includes('Adicionar Agendamento'));
+    assert.ok(markup.includes('name="nome_paciente"'));
+    assert.ok(markup.includes('Confirmado'));
   });
 
   test('filterAppointmentsBySearch finds matches by CPF digits and name', () => {

--- a/frontend/src/types/appointment.ts
+++ b/frontend/src/types/appointment.ts
@@ -47,6 +47,24 @@ export interface AppointmentViewModel extends Appointment {
   healthPlanLabel: string;
 }
 
+export interface AppointmentCreateRequest {
+  nome_marca: string;
+  nome_unidade: string;
+  nome_paciente: string;
+  data_agendamento: string;
+  hora_agendamento: string;
+  tipo_consulta?: string;
+  status?: string;
+  telefone: string;
+  carro?: string;
+  observacoes?: string;
+  driver_id?: string;
+  collector_id?: string;
+  numero_convenio?: string;
+  nome_convenio?: string;
+  carteira_convenio?: string;
+}
+
 export interface AppointmentFilter {
   nome_unidade?: string;
   nome_marca?: string;
@@ -104,4 +122,10 @@ export interface DashboardStats {
     total_units: number;
     total_brands: number;
   };
+}
+
+export interface AppointmentCreateResponse {
+  success: boolean;
+  message: string;
+  data: Appointment;
 }

--- a/frontend/src/utils/appointmentViewModel.ts
+++ b/frontend/src/utils/appointmentViewModel.ts
@@ -7,6 +7,18 @@ export interface DateRange {
   end: Date;
 }
 
+export const APPOINTMENT_STATUS_OPTIONS = [
+  'Pendente',
+  'Autorização',
+  'Cadastrar',
+  'Agendado',
+  'Confirmado',
+  'Coletado',
+  'Alterar',
+  'Cancelado',
+  'Recoleta',
+] as const;
+
 const onlyDigits = (value: string | null | undefined): string => value ? value.replace(/\D/g, '') : '';
 
 export const maskCpf = (cpf: string | null | undefined): string => {


### PR DESCRIPTION
## Summary
- add manual appointment creation service, endpoint and validation
- expose manual booking modal on the appointments page with toast feedback
- cover changes with backend tests, smoke checks and updated documentation

## Testing
- PYTEST_ADDOPTS="--no-cov" pytest backend/tests/test_appointment_service.py backend/tests/test_appointment_api.py
- npm run test