### PR TITLE
feat: add tags management for appointments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,11 @@ Use `make quick-start` for a full-stack boot with health checks, or `docker-comp
 ## Coding Style & Naming Conventions
 Python modules use 4-space indentation, snake_case for files/functions, and PascalCase for Pydantic models or services; validate formatting with `make format-backend`. TypeScript components sit in PascalCase files, React hooks start with `use`, and shared helpers live in `frontend/src/utils`. Tailwind utility classes stay inline, while shared styles move to composable components. Before committing, run `npm run lint` and `npx prettier --write .` via `make format-frontend` to align with the ESLint/Prettier baseline.
 
+### Frontend TypeScript & React Query specifics
+- The project uses TanStack Query v5. Always pass explicit generics to hooks like `useQuery`/`useMutation` so the compiler knows the data shape.
+- To preserve previous data while paginating, use `placeholderData: keepPreviousData` (imported from `@tanstack/react-query`) instead of the deprecated `keepPreviousData` option.
+- Keep the config aligned with TypeScript `noImplicitAny`; if a callback parameter needs typing (e.g., `map(tag => …)`), annotate it.
+
 ## Testing Guidelines
 Mirror backend module names with `test_<module>.py` files and lean on fixtures in `backend/tests/conftest.py`; add integration tests whenever repositories or external gateways change. Frontend specs belong next to their components with a `.test.tsx` suffix and run through `npm test`. End-to-end flows live in the top-level `tests/` package—seed sample data via `make db-seed` and execute `npm run e2e` from that directory.
 

--- a/frontend/src/pages/TagsPage.tsx
+++ b/frontend/src/pages/TagsPage.tsx
@@ -3,13 +3,18 @@ import {
   PlusIcon,
   TrashIcon,
 } from '@heroicons/react/24/outline';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  keepPreviousData,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
 import React, { useEffect, useMemo, useState } from 'react';
 import { TagFormModal, type TagFormValues } from '../components/tags/TagFormModal';
 import { TagBadge } from '../components/tags/TagBadge';
 import { ToastContainer } from '../components/ui/Toast';
 import { useToast } from '../hooks/useToast';
-import type { Tag } from '../types/tag';
+import type { Tag, TagListResponse } from '../types/tag';
 import { tagAPI } from '../services/api';
 import { formatDateTimeLabel } from '../utils/dateUtils';
 
@@ -34,7 +39,7 @@ export const TagsPage: React.FC = () => {
     return () => window.clearTimeout(handle);
   }, [searchInput]);
 
-  const tagsQuery = useQuery({
+  const tagsQuery = useQuery<TagListResponse>({
     queryKey: ['tags', { page, search, includeInactive }],
     queryFn: () =>
       tagAPI.listTags({
@@ -43,7 +48,7 @@ export const TagsPage: React.FC = () => {
         search: search || undefined,
         include_inactive: includeInactive,
       }),
-    keepPreviousData: true,
+    placeholderData: keepPreviousData,
   });
 
   const closeModal = () => {
@@ -148,7 +153,7 @@ export const TagsPage: React.FC = () => {
   const totalPages = data?.pages ?? 1;
   const totalItems = data?.total ?? 0;
 
-  const tableRows = useMemo(() => data?.data ?? [], [data]);
+  const tableRows = useMemo<Tag[]>(() => data?.data ?? [], [data]);
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
## Summary
- reabre a funcionalidade de gestão de tags após merge anterior
- mantém ajustes do frontend/backend e documentação já validados

## Testing
- ./venv/bin/python -m pytest --no-cov tests/test_tag_service.py tests/test_appointment_service.py tests/test_appointment_repository.py tests/test_appointment_entity.py
- npm run build
