### PR TITLE
fix: normalize collector CPF and surface duplicate errors

### DIFF
--- a/backend/src/application/dtos/collector_dto.py
+++ b/backend/src/application/dtos/collector_dto.py
@@ -8,6 +8,8 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field, field_validator
 
+from src.domain.utils import normalize_cpf
+
 
 class CollectorCreateDTO(BaseModel):
     """DTO for creating a new collector."""
@@ -29,6 +31,15 @@ class CollectorCreateDTO(BaseModel):
         None, description="Registro profissional"
     )
     especializacao: Optional[str] = Field(None, description="Especialização")
+
+    @field_validator("cpf", mode="before")
+    @classmethod
+    def normalize_cpf_value(cls, value: str) -> str:
+        """Ensure CPF is stored using only digits."""
+        normalized = normalize_cpf(value)
+        if not normalized:
+            raise ValueError("CPF é obrigatório")
+        return normalized
 
     @field_validator("data_nascimento", mode="before")
     @classmethod
@@ -96,6 +107,16 @@ class CollectorUpdateDTO(BaseModel):
     observacoes: Optional[str] = None
     registro_profissional: Optional[str] = None
     especializacao: Optional[str] = None
+
+    @field_validator("cpf", mode="before")
+    @classmethod
+    def normalize_optional_cpf(
+        cls, value: Optional[str]
+    ) -> Optional[str]:
+        """Normalize CPF when provided in updates."""
+        if value in (None, ""):
+            return None
+        return normalize_cpf(value)
 
     @field_validator("data_nascimento", mode="before")
     @classmethod

--- a/backend/src/domain/utils/__init__.py
+++ b/backend/src/domain/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utility helpers for domain layer."""
+
+from .cpf import normalize_cpf
+
+__all__ = ["normalize_cpf"]

--- a/backend/src/domain/utils/cpf.py
+++ b/backend/src/domain/utils/cpf.py
@@ -1,0 +1,20 @@
+"""CPF utilities for normalization and validation helpers."""
+
+import re
+from typing import Optional
+
+
+def normalize_cpf(cpf: Optional[str]) -> Optional[str]:
+    """Return CPF digits only, preserving None values.
+
+    Args:
+        cpf: CPF value possibly containing formatting characters.
+
+    Returns:
+        Normalized CPF with only numbers or None when no value was provided.
+    """
+    if cpf is None:
+        return None
+
+    digits = re.sub(r"\D", "", cpf)
+    return digits or None

--- a/backend/tests/test_collector_repository.py
+++ b/backend/tests/test_collector_repository.py
@@ -1,0 +1,48 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.infrastructure.repositories.collector_repository import CollectorRepository
+
+
+@pytest.mark.asyncio
+async def test_find_by_cpf_handles_formatted_legacy_values():
+    legacy_document = {
+        "id": "123e4567-e89b-12d3-a456-426614174000",
+        "nome_completo": "Maria Silva",
+        "cpf": "529.982.247-25",
+        "telefone": "11987654321",
+        "status": "Ativo",
+        "created_at": datetime.now(timezone.utc),
+        "updated_at": None,
+    }
+
+    collection = SimpleNamespace(
+        find_one=AsyncMock(side_effect=[None, legacy_document])
+    )
+    repository = CollectorRepository(SimpleNamespace(collectors=collection))
+
+    collector = await repository.find_by_cpf("529.982.247-25")
+
+    assert collector is not None
+    assert collector.cpf == "52998224725"
+    assert collection.find_one.await_args_list[0].args[0] == {"cpf": "52998224725"}
+    regex_query = collection.find_one.await_args_list[1].args[0]
+    assert "$regex" in regex_query["cpf"]
+
+
+@pytest.mark.asyncio
+async def test_exists_by_cpf_handles_formatted_values():
+    collection = SimpleNamespace(
+        find_one=AsyncMock(side_effect=[None, {"_id": "abc123"}])
+    )
+    repository = CollectorRepository(SimpleNamespace(collectors=collection))
+
+    exists = await repository.exists_by_cpf("529.982.247-25")
+
+    assert exists is True
+    assert collection.find_one.await_args_list[0].args[0] == {"cpf": "52998224725"}
+    regex_query = collection.find_one.await_args_list[1].args[0]
+    assert "$regex" in regex_query["cpf"]

--- a/backend/tests/test_collector_service.py
+++ b/backend/tests/test_collector_service.py
@@ -1,0 +1,37 @@
+import pytest
+from unittest.mock import AsyncMock
+
+from src.application.dtos.collector_dto import CollectorCreateDTO
+from src.application.services.collector_service import CollectorService
+from src.domain.entities.collector import Collector
+
+
+@pytest.mark.asyncio
+async def test_create_collector_normalizes_cpf_before_uniqueness_check():
+    repository = AsyncMock()
+    repository.find_by_cpf.return_value = None
+
+    stored_collector = Collector(
+        nome_completo="Maria Silva",
+        cpf="52998224725",
+        telefone="11987654321",
+        email="maria@example.com",
+    )
+    repository.create.return_value = stored_collector
+
+    service = CollectorService(repository)
+
+    dto = CollectorCreateDTO(
+        nome_completo="Maria Silva",
+        cpf="529.982.247-25",
+        telefone="(11) 98765-4321",
+        email="maria@example.com",
+        status="Ativo",
+    )
+
+    result = await service.create_collector(dto)
+
+    repository.find_by_cpf.assert_awaited_once_with("52998224725")
+    repository.create.assert_awaited_once()
+    assert result["success"] is True
+    assert result["collector"].cpf == "52998224725"

--- a/frontend/src/components/CollectorForm.tsx
+++ b/frontend/src/components/CollectorForm.tsx
@@ -8,6 +8,8 @@ interface CollectorFormProps {
   onClose: () => void;
   onSubmit: (data: CollectorFormData) => void;
   isLoading?: boolean;
+  serverError?: string;
+  onServerErrorClear?: () => void;
 }
 
 const initialFormData: CollectorFormData = {
@@ -29,7 +31,9 @@ export const CollectorForm: React.FC<CollectorFormProps> = ({
   isOpen,
   onClose,
   onSubmit,
-  isLoading = false
+  isLoading = false,
+  serverError,
+  onServerErrorClear,
 }) => {
   const [formData, setFormData] = useState<CollectorFormData>(initialFormData);
   const [errors, setErrors] = useState<Partial<CollectorFormData>>({});
@@ -100,7 +104,11 @@ export const CollectorForm: React.FC<CollectorFormProps> = ({
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>
   ) => {
     const { name, value } = e.target;
-    
+
+    if (serverError) {
+      onServerErrorClear?.();
+    }
+
     // For CPF, only allow numbers
     if (name === 'cpf') {
       const cleanValue = value.replace(/\D/g, '');
@@ -203,6 +211,11 @@ export const CollectorForm: React.FC<CollectorFormProps> = ({
 
         {/* Form */}
         <form onSubmit={handleSubmit} className="p-6 space-y-4">
+          {serverError && (
+            <div className="p-3 text-sm font-medium text-red-700 bg-red-50 border border-red-200 rounded-md">
+              {serverError}
+            </div>
+          )}
           {/* Nome Completo */}
           <div>
             <label htmlFor="nome_completo" className="block text-sm font-medium text-gray-700 mb-1">

--- a/frontend/src/pages/CollectorsPage.tsx
+++ b/frontend/src/pages/CollectorsPage.tsx
@@ -28,6 +28,7 @@ export const CollectorsPage: React.FC = () => {
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [selectedCollector, setSelectedCollector] = useState<Collector | undefined>();
   const [error, setError] = useState<string | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
 
   // Fetch collectors
   const { 
@@ -57,9 +58,12 @@ export const CollectorsPage: React.FC = () => {
       queryClient.invalidateQueries({ queryKey: ['collectorStats'] });
       setIsFormOpen(false);
       setError(null);
+      setFormError(null);
     },
     onError: (error: any) => {
-      setError(error.response?.data?.detail || 'Erro ao criar coletora');
+      const message = error.response?.data?.detail || error.response?.data?.message || 'Erro ao criar coletora';
+      setFormError(message);
+      setError(message);
     }
   });
 
@@ -73,9 +77,12 @@ export const CollectorsPage: React.FC = () => {
       setIsFormOpen(false);
       setSelectedCollector(undefined);
       setError(null);
+      setFormError(null);
     },
     onError: (error: any) => {
-      setError(error.response?.data?.detail || 'Erro ao atualizar coletora');
+      const message = error.response?.data?.detail || error.response?.data?.message || 'Erro ao atualizar coletora';
+      setFormError(message);
+      setError(message);
     }
   });
 
@@ -110,6 +117,9 @@ export const CollectorsPage: React.FC = () => {
       data_nascimento: data.data_nascimento || undefined,
     };
 
+    setFormError(null);
+    setError(null);
+
     if (selectedCollector) {
       updateCollectorMutation.mutate({ id: selectedCollector.id, data: requestData });
     } else {
@@ -120,6 +130,7 @@ export const CollectorsPage: React.FC = () => {
   const handleEdit = (collector: Collector) => {
     setSelectedCollector(collector);
     setIsFormOpen(true);
+    setFormError(null);
   };
 
   const handleStatusChange = (id: string, status: string) => {
@@ -144,12 +155,15 @@ export const CollectorsPage: React.FC = () => {
   const handleNewCollector = () => {
     setSelectedCollector(undefined);
     setIsFormOpen(true);
+    setFormError(null);
+    setError(null);
   };
 
   const handleCloseForm = () => {
     setIsFormOpen(false);
     setSelectedCollector(undefined);
     setError(null);
+    setFormError(null);
   };
 
   const stats = collectorStats?.stats || {
@@ -318,6 +332,8 @@ export const CollectorsPage: React.FC = () => {
         onClose={handleCloseForm}
         onSubmit={handleFormSubmit}
         isLoading={isFormLoading}
+        serverError={formError ?? undefined}
+        onServerErrorClear={() => setFormError(null)}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- normalize CPF nos DTOs e repositório para unificar validações
- detectar CPFs legados formatados para evitar falsos conflitos
- exibir mensagem de erro no modal ao receber 409 e limpar ao editar

## Affected Services
- backend
- frontend
- tests

## Testing
- pytest backend/tests/test_collector_service.py backend/tests/test_collector_repository.py *(falha gate de cobertura global)*