### PR TITLE
feat: support appointments without scheduled time

### DIFF
--- a/backend/src/application/dtos/appointment_dto.py
+++ b/backend/src/application/dtos/appointment_dto.py
@@ -17,13 +17,17 @@ class AppointmentCreateDTO(BaseModel):
     nome_marca: str = Field(..., description="Nome da Marca")
     nome_unidade: str = Field(..., description="Nome da Unidade")
     nome_paciente: str = Field(..., description="Nome do Paciente")
-    data_agendamento: datetime = Field(..., description="Data do Agendamento")
-    hora_agendamento: str = Field(..., description="Hora do Agendamento")
+    data_agendamento: Optional[datetime] = Field(
+        None, description="Data do Agendamento"
+    )
+    hora_agendamento: Optional[str] = Field(
+        None, description="Hora do Agendamento"
+    )
     tipo_consulta: Optional[str] = Field(None, description="Tipo de Consulta")
     cip: Optional[str] = Field(
         None, description="Código CIP (Classificação Internacional de Procedimentos)"
     )
-    status: str = Field("Confirmado", description="Status do Agendamento")
+    status: str = Field("Pendente", description="Status do Agendamento")
     telefone: Optional[str] = Field(None, description="Telefone do Paciente")
     carro: Optional[str] = Field(
         None, description="Informações do carro utilizado"
@@ -59,8 +63,8 @@ class AppointmentResponseDTO(BaseModel):
     nome_marca: str
     nome_unidade: str
     nome_paciente: str
-    data_agendamento: datetime
-    hora_agendamento: str
+    data_agendamento: Optional[datetime] = None
+    hora_agendamento: Optional[str] = None
     tipo_consulta: Optional[str] = None
     cip: Optional[str] = None
     status: str

--- a/backend/src/domain/entities/appointment.py
+++ b/backend/src/domain/entities/appointment.py
@@ -23,9 +23,11 @@ class Appointment(Entity):
     nome_unidade: str = Field(..., description="Nome da Unidade de Saúde")
     nome_marca: str = Field(..., description="Nome da Marca/Clínica")
     nome_paciente: str = Field(..., description="Nome completo do paciente")
-    data_agendamento: datetime = Field(..., description="Data do agendamento")
-    hora_agendamento: str = Field(
-        ..., description="Hora do agendamento (HH:MM)"
+    data_agendamento: Optional[datetime] = Field(
+        None, description="Data do agendamento"
+    )
+    hora_agendamento: Optional[str] = Field(
+        None, description="Hora do agendamento (HH:MM)"
     )
 
     # Optional fields
@@ -124,13 +126,17 @@ class Appointment(Entity):
 
     @field_validator("hora_agendamento")
     @classmethod
-    def validate_time_format(cls, value: str) -> str:
+    def validate_time_format(cls, value: Optional[str]) -> Optional[str]:
         """Validate time format (HH:MM)."""
-        if not value:
-            raise ValueError("Hora do agendamento é obrigatória")
+        if value is None:
+            return None
 
         # Basic validation for HH:MM format
-        parts = value.strip().split(":")
+        trimmed = value.strip()
+        if not trimmed:
+            return None
+
+        parts = trimmed.split(":")
         if len(parts) != 2:
             raise ValueError("Hora deve estar no formato HH:MM")
 

--- a/backend/src/infrastructure/repositories/appointment_repository.py
+++ b/backend/src/infrastructure/repositories/appointment_repository.py
@@ -342,7 +342,10 @@ class AppointmentRepository(AppointmentRepositoryInterface):
         duplicate_ids = []
 
         for appointment in appointments:
-            # Build query for potential duplicates
+            # Only run duplicate checks when date and time are provided
+            if not (appointment.data_agendamento and appointment.hora_agendamento):
+                continue
+
             query = {
                 "nome_paciente": appointment.nome_paciente,
                 "data_agendamento": appointment.data_agendamento,
@@ -350,7 +353,6 @@ class AppointmentRepository(AppointmentRepositoryInterface):
                 "nome_unidade": appointment.nome_unidade,
             }
 
-            # Check if appointment with these key fields already exists
             existing = await self.collection.find_one(query)
             if existing:
                 duplicate_ids.append(str(appointment.id))

--- a/frontend/src/components/AppointmentCard.tsx
+++ b/frontend/src/components/AppointmentCard.tsx
@@ -184,11 +184,11 @@ export const AppointmentCard: React.FC<AppointmentCardProps> = ({
             <div className={`mt-1 flex flex-wrap items-center gap-2 ${detailValueClass}`}>
               <span className="inline-flex items-center gap-1 rounded-full bg-gray-50 px-2 py-1 font-medium text-gray-600">
                 <CalendarIcon className="w-3 h-3" />
-                {formatDate(appointment.data_agendamento)}
+                {formatDate(appointment.data_agendamento ?? '')}
               </span>
               <span className="inline-flex items-center gap-1 rounded-full bg-gray-50 px-2 py-1 font-medium text-gray-600">
                 <ClockIcon className="w-3 h-3" />
-                {appointment.hora_agendamento}
+                {appointment.hora_agendamento ?? 'Sem hora definida'}
               </span>
             </div>
           </div>

--- a/frontend/src/components/AppointmentDetailsModal.tsx
+++ b/frontend/src/components/AppointmentDetailsModal.tsx
@@ -576,7 +576,7 @@ export function AppointmentDetailsModal({
           { label: 'Nome do paciente', value: ensureValue(appointment.nome_paciente) },
           { label: 'Tipo de consulta', value: ensureValue(appointment.tipo_consulta) },
           { label: 'CIP', value: ensureValue(appointment.cip) },
-          { label: 'Data do agendamento', value: formatDate(appointment.data_agendamento) },
+          { label: 'Data do agendamento', value: formatDate(appointment.data_agendamento ?? '') },
           { label: 'Hora do agendamento', value: ensureValue(appointment.hora_agendamento) },
           { label: 'Status', value: ensureValue(appointment.status), variant: 'status' },
           { label: 'Carro', value: carInfo },
@@ -737,7 +737,7 @@ export function AppointmentDetailsModal({
             ) : (
               <span>—</span>
             )}
-            <span>{formatDate(appointment.data_agendamento)}</span>
+            <span>{formatDate(appointment.data_agendamento ?? '')}</span>
             <span>{ensureValue(appointment.hora_agendamento)}</span>
           </div>
         </div>

--- a/frontend/src/components/CalendarDayModal.tsx
+++ b/frontend/src/components/CalendarDayModal.tsx
@@ -125,7 +125,7 @@ export const CalendarDayModal: React.FC<DayModalProps> = ({
                         <div className="flex items-center space-x-1">
                           <ClockIcon className="w-4 h-4" />
                           <span>
-                            Horários: {appointments[0]?.hora_agendamento} - {appointments[appointments.length - 1]?.hora_agendamento}
+                            Horários: {appointments[0]?.hora_agendamento ?? 'Sem horário'} - {appointments[appointments.length - 1]?.hora_agendamento ?? 'Sem horário'}
                           </span>
                         </div>
                       </div>

--- a/frontend/src/components/NavigationBar.tsx
+++ b/frontend/src/components/NavigationBar.tsx
@@ -78,7 +78,8 @@ export const NavigationBar: React.FC<NavigationBarProps> = ({ appointments }) =>
         
         {nextStop && (
           <div className="mt-2 text-center text-sm text-gray-600">
-            <strong>Próxima parada:</strong> {nextStop.hora_agendamento} - {nextStop.nome_paciente}
+            <strong>Próxima parada:</strong>{' '}
+            {nextStop.hora_agendamento ?? 'Sem hora definida'} - {nextStop.nome_paciente}
           </div>
         )}
       </div>

--- a/frontend/src/pages/DriverRoutePage.tsx
+++ b/frontend/src/pages/DriverRoutePage.tsx
@@ -60,7 +60,14 @@ export const DriverRoutePage: React.FC = () => {
         <div className="grid grid-cols-12 items-center gap-4">
           <div className="col-span-12 md:col-span-6 flex items-center gap-4">
             <div className="text-6xl md:text-7xl font-black text-gray-900 tabular-nums">
-              {(ap.hora_agendamento || '').padStart(5, '0')}
+              {(() => {
+                const time = ap.hora_agendamento;
+                if (!time) {
+                  return '--:--';
+                }
+                const match = time.match(/^(\d{2}:\d{2})/);
+                return match ? match[1] : '--:--';
+              })()}
             </div>
             <div className="hidden md:block h-10 w-px bg-gray-800" />
             <div className="flex flex-wrap gap-8 text-lg font-bold text-gray-900">
@@ -196,8 +203,15 @@ export const DriverRoutePage: React.FC = () => {
 
   // ordena horário
   const ordered = (appts || []).slice().sort((a, b) => {
-    const [ah, am] = (a.hora_agendamento || '00:00').split(':').map(Number);
-    const [bh, bm] = (b.hora_agendamento || '00:00').split(':').map(Number);
+    const normalizeTime = (value?: string | null): string => {
+      if (!value || !value.trim()) {
+        return '99:99';
+      }
+      return value;
+    };
+
+    const [ah, am] = normalizeTime(a.hora_agendamento).split(':').map(Number);
+    const [bh, bm] = normalizeTime(b.hora_agendamento).split(':').map(Number);
     return ah === bh ? am - bm : ah - bh;
   });
 
@@ -272,5 +286,4 @@ function isNac(ap: Appointment): boolean {
   if (!unidade && marca) return true;
   return marca.includes('nac');
 }
-
 

--- a/frontend/src/types/appointment.ts
+++ b/frontend/src/types/appointment.ts
@@ -9,8 +9,8 @@ export interface Appointment {
   nome_marca: string;
   nome_unidade: string;
   nome_paciente: string;
-  data_agendamento: string;
-  hora_agendamento: string;
+  data_agendamento?: string | null;
+  hora_agendamento?: string | null;
   tipo_consulta?: string;
   cip?: string;
   status: string;
@@ -65,8 +65,8 @@ export interface AppointmentCreateRequest {
   nome_marca: string;
   nome_unidade: string;
   nome_paciente: string;
-  data_agendamento: string;
-  hora_agendamento: string;
+  data_agendamento?: string;
+  hora_agendamento?: string;
   tipo_consulta?: string;
   cip?: string;
   status?: string;

--- a/frontend/src/utils/agendaHelpers.ts
+++ b/frontend/src/utils/agendaHelpers.ts
@@ -74,8 +74,14 @@ export function groupAppointmentsByDate(appointments: AppointmentViewModel[]): A
   const grouped: AppointmentsByDate = {};
   
   appointments.forEach(appointment => {
-    // Parse da data do agendamento
+    if (!appointment.data_agendamento) {
+      return;
+    }
+
     const appointmentDate = parseISO(appointment.data_agendamento);
+    if (Number.isNaN(appointmentDate.getTime())) {
+      return;
+    }
     const dateKey = format(appointmentDate, 'yyyy-MM-dd');
     
     if (!grouped[dateKey]) {
@@ -88,8 +94,15 @@ export function groupAppointmentsByDate(appointments: AppointmentViewModel[]): A
   // Ordena os agendamentos de cada dia por hora
   Object.keys(grouped).forEach(dateKey => {
     grouped[dateKey].sort((a, b) => {
-      const timeA = a.hora_agendamento || '00:00';
-      const timeB = b.hora_agendamento || '00:00';
+      const safeTime = (value?: string | null): string => {
+        if (!value || !value.trim()) {
+          return '99:99';
+        }
+        return value;
+      };
+
+      const timeA = safeTime(a.hora_agendamento);
+      const timeB = safeTime(b.hora_agendamento);
       return timeA.localeCompare(timeB);
     });
   });

--- a/frontend/src/utils/navigationHelpers.ts
+++ b/frontend/src/utils/navigationHelpers.ts
@@ -77,8 +77,8 @@ export function getNextStop(appointments: Appointment[]): Appointment | null {
   
   // Ordena por horário e retorna a primeira
   const ordered = appointments.slice().sort((a, b) => {
-    const [ah, am] = (a.hora_agendamento || '00:00').split(':').map(Number);
-    const [bh, bm] = (b.hora_agendamento || '00:00').split(':').map(Number);
+    const [ah, am] = (a.hora_agendamento || '99:99').split(':').map(Number);
+    const [bh, bm] = (b.hora_agendamento || '99:99').split(':').map(Number);
     return ah === bh ? am - bm : ah - bh;
   });
   
@@ -93,8 +93,8 @@ export function getWaypointsForRoute(appointments: Appointment[]): string[] {
   
   // Ordena por horário
   const ordered = appointments.slice().sort((a, b) => {
-    const [ah, am] = (a.hora_agendamento || '00:00').split(':').map(Number);
-    const [bh, bm] = (b.hora_agendamento || '00:00').split(':').map(Number);
+    const [ah, am] = (a.hora_agendamento || '99:99').split(':').map(Number);
+    const [bh, bm] = (b.hora_agendamento || '99:99').split(':').map(Number);
     return ah === bh ? am - bm : ah - bh;
   });
   
@@ -110,8 +110,8 @@ export function getFinalDestination(appointments: Appointment[]): string {
   
   // Ordena por horário e retorna o último
   const ordered = appointments.slice().sort((a, b) => {
-    const [ah, am] = (a.hora_agendamento || '00:00').split(':').map(Number);
-    const [bh, bm] = (b.hora_agendamento || '00:00').split(':').map(Number);
+    const [ah, am] = (a.hora_agendamento || '99:99').split(':').map(Number);
+    const [bh, bm] = (b.hora_agendamento || '99:99').split(':').map(Number);
     return ah === bh ? am - bm : ah - bh;
   });
   


### PR DESCRIPTION
## Summary
- allow creating appointments without required date/time by making backend fields optional and skipping duplicate checks when missing
- lock creation modal to default brand/unit, default status Pendente, and avoid submitting empty scheduling data
- update UI sorting and displays to handle appointments without defined schedule information

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*
- make test-backend *(fails: backend container not running)*