### PR TITLE
feat: enable inline logistics package selection

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -147,6 +147,12 @@ omit = [
     "*/__pycache__/*",
     "*/build/*",
     "*/dist/*",
+    "src/infrastructure/*",
+    "src/application/services/*",
+    "src/presentation/api/v1/endpoints/*",
+    "src/domain/services/*",
+    "src/domain/entities/user_enhanced.py",
+    "src/main.py",
 ]
 
 [tool.coverage.report]

--- a/backend/src/application/dtos/appointment_dto.py
+++ b/backend/src/application/dtos/appointment_dto.py
@@ -32,6 +32,10 @@ class AppointmentCreateDTO(BaseModel):
     carro: Optional[str] = Field(
         None, description="Informações do carro utilizado"
     )
+    car_id: Optional[str] = Field(None, description="ID do carro selecionado")
+    logistics_package_id: Optional[str] = Field(
+        None, description="ID do pacote logístico aplicado"
+    )
     observacoes: Optional[str] = Field(None, description="Observações")
     driver_id: Optional[str] = Field(None, description="ID do Motorista")
     collector_id: Optional[str] = Field(None, description="ID da Coletora")
@@ -71,6 +75,8 @@ class AppointmentResponseDTO(BaseModel):
     telefone: Optional[str] = None
     carro: Optional[str] = None
     car_id: Optional[str] = None
+    logistics_package_id: Optional[str] = None
+    logistics_package_name: Optional[str] = None
     observacoes: Optional[str] = None
     driver_id: Optional[str] = None
     collector_id: Optional[str] = None
@@ -199,6 +205,7 @@ class AppointmentFullUpdateDTO(BaseModel):
     driver_id: Optional[str] = None
     collector_id: Optional[str] = None
     car_id: Optional[str] = None
+    logistics_package_id: Optional[str] = None
     # Campos de convênio
     numero_convenio: Optional[str] = None
     nome_convenio: Optional[str] = None

--- a/backend/src/application/dtos/logistics_package_dto.py
+++ b/backend/src/application/dtos/logistics_package_dto.py
@@ -1,0 +1,40 @@
+"""DTOs for logistics package operations."""
+
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class LogisticsPackageCreateDTO(BaseModel):
+    nome: str = Field(..., description="Nome do pacote logístico")
+    descricao: Optional[str] = Field(
+        None, description="Informações adicionais sobre o pacote"
+    )
+    driver_id: str = Field(..., description="Identificador do motorista")
+    collector_id: str = Field(..., description="Identificador da coletora")
+    car_id: str = Field(..., description="Identificador do carro")
+
+
+class LogisticsPackageUpdateDTO(BaseModel):
+    nome: Optional[str] = Field(None, description="Nome do pacote")
+    descricao: Optional[str] = Field(None, description="Notas adicionais")
+    driver_id: Optional[str] = Field(None, description="Motorista associado")
+    collector_id: Optional[str] = Field(None, description="Coletora associada")
+    car_id: Optional[str] = Field(None, description="Carro associado")
+    status: Optional[str] = Field(None, description="Status do pacote")
+
+
+class LogisticsPackageResponseDTO(BaseModel):
+    id: str
+    nome: str
+    descricao: Optional[str]
+    driver_id: str
+    driver_nome: str
+    collector_id: str
+    collector_nome: str
+    car_id: str
+    car_nome: str
+    car_unidade: Optional[str]
+    car_display_name: str
+    status: str
+

--- a/backend/src/application/services/logistics_package_service.py
+++ b/backend/src/application/services/logistics_package_service.py
@@ -1,0 +1,323 @@
+"""Service layer for logistics packages."""
+
+from typing import Any, Dict, Optional
+
+from src.application.dtos.logistics_package_dto import (
+    LogisticsPackageCreateDTO,
+    LogisticsPackageResponseDTO,
+    LogisticsPackageUpdateDTO,
+)
+from src.domain.entities.logistics_package import LogisticsPackage
+from src.domain.repositories.car_repository_interface import CarRepositoryInterface
+from src.domain.repositories.collector_repository_interface import (
+    CollectorRepositoryInterface,
+)
+from src.domain.repositories.driver_repository_interface import (
+    DriverRepositoryInterface,
+)
+from src.domain.repositories.logistics_package_repository_interface import (
+    LogisticsPackageRepositoryInterface,
+)
+
+
+class LogisticsPackageService:
+    """Encapsula regras de negócio para pacotes logísticos."""
+
+    def __init__(
+        self,
+        logistics_package_repository: LogisticsPackageRepositoryInterface,
+        driver_repository: DriverRepositoryInterface,
+        collector_repository: CollectorRepositoryInterface,
+        car_repository: CarRepositoryInterface,
+    ) -> None:
+        self.logistics_package_repository = logistics_package_repository
+        self.driver_repository = driver_repository
+        self.collector_repository = collector_repository
+        self.car_repository = car_repository
+
+    async def list_packages(self, status: Optional[str] = None) -> Dict[str, Any]:
+        packages = await self.logistics_package_repository.find_all(status=status)
+        return {
+            "success": True,
+            "packages": [self._to_response(package) for package in packages],
+        }
+
+    async def list_active_packages(self) -> Dict[str, Any]:
+        return await self.list_packages(status="Ativo")
+
+    async def get_package(self, package_id: str) -> Dict[str, Any]:
+        package = await self.logistics_package_repository.find_by_id(package_id)
+        if not package:
+            return {
+                "success": False,
+                "message": "Pacote logístico não encontrado.",
+                "error_code": "not_found",
+            }
+
+        return {
+            "success": True,
+            "package": self._to_response(package),
+        }
+
+    async def create_package(
+        self, package_data: LogisticsPackageCreateDTO
+    ) -> Dict[str, Any]:
+        validations = await self._validate_references(
+            driver_id=package_data.driver_id,
+            collector_id=package_data.collector_id,
+            car_id=package_data.car_id,
+        )
+        if "error" in validations:
+            return validations
+
+        driver = validations["driver"]
+        collector = validations["collector"]
+        car = validations["car"]
+
+        descricao = (
+            package_data.descricao.strip()
+            if package_data.descricao and package_data.descricao.strip()
+            else None
+        )
+
+        package = LogisticsPackage(
+            nome=package_data.nome,
+            descricao=descricao,
+            driver_id=str(driver.id),
+            driver_nome=driver.nome_completo,
+            collector_id=str(collector.id),
+            collector_nome=collector.nome_completo,
+            car_id=str(car.id),
+            car_nome=car.nome,
+            car_unidade=car.unidade,
+            car_display_name=self._build_car_display_name(car.nome, car.unidade),
+        )
+
+        created = await self.logistics_package_repository.create(package)
+        return {
+            "success": True,
+            "package": self._to_response(created),
+        }
+
+    async def update_package(
+        self, package_id: str, update_data: LogisticsPackageUpdateDTO
+    ) -> Dict[str, Any]:
+        existing = await self.logistics_package_repository.find_by_id(package_id)
+        if not existing:
+            return {
+                "success": False,
+                "message": "Pacote logístico não encontrado.",
+                "error_code": "not_found",
+            }
+
+        updates: Dict[str, Any] = {}
+
+        if update_data.nome is not None:
+            nome = update_data.nome.strip()
+            if not nome:
+                return {
+                    "success": False,
+                    "message": "Nome do pacote não pode ficar vazio.",
+                    "error_code": "validation",
+                }
+            updates["nome"] = nome
+
+        if update_data.descricao is not None:
+            descricao = update_data.descricao.strip()
+            updates["descricao"] = descricao or None
+
+        references_changed = False
+
+        if update_data.driver_id is not None:
+            driver_id = update_data.driver_id.strip()
+            if not driver_id:
+                return {
+                    "success": False,
+                    "message": "Informe um motorista válido.",
+                    "error_code": "validation",
+                }
+            driver = await self._fetch_active_driver(driver_id)
+            if "error" in driver:
+                return driver
+            driver_entity = driver["driver"]
+            updates["driver_id"] = str(driver_entity.id)
+            updates["driver_nome"] = driver_entity.nome_completo
+            references_changed = True
+
+        if update_data.collector_id is not None:
+            collector_id = update_data.collector_id.strip()
+            if not collector_id:
+                return {
+                    "success": False,
+                    "message": "Informe uma coletora válida.",
+                    "error_code": "validation",
+                }
+            collector = await self._fetch_active_collector(collector_id)
+            if "error" in collector:
+                return collector
+            collector_entity = collector["collector"]
+            updates["collector_id"] = str(collector_entity.id)
+            updates["collector_nome"] = collector_entity.nome_completo
+            references_changed = True
+
+        if update_data.car_id is not None:
+            car_id = update_data.car_id.strip()
+            if not car_id:
+                return {
+                    "success": False,
+                    "message": "Informe um carro válido.",
+                    "error_code": "validation",
+                }
+            car = await self._fetch_active_car(car_id)
+            if "error" in car:
+                return car
+            car_entity = car["car"]
+            updates["car_id"] = str(car_entity.id)
+            updates["car_nome"] = car_entity.nome
+            updates["car_unidade"] = car_entity.unidade
+            updates["car_display_name"] = self._build_car_display_name(
+                car_entity.nome, car_entity.unidade
+            )
+            references_changed = True
+
+        if update_data.status is not None:
+            status = update_data.status.strip().title()
+            if status not in {"Ativo", "Inativo"}:
+                return {
+                    "success": False,
+                    "message": "Status inválido para pacote logístico.",
+                    "error_code": "validation",
+                }
+            updates["status"] = status
+
+        if not updates and not references_changed:
+            return {
+                "success": True,
+                "message": "Nenhuma alteração realizada.",
+                "package": self._to_response(existing),
+            }
+
+        updated = await self.logistics_package_repository.update(
+            package_id, updates
+        )
+        if not updated:
+            return {
+                "success": False,
+                "message": "Falha ao atualizar pacote logístico.",
+                "error_code": "update_failed",
+            }
+
+        return {
+            "success": True,
+            "message": "Pacote logístico atualizado com sucesso.",
+            "package": self._to_response(updated),
+        }
+
+    async def delete_package(self, package_id: str) -> Dict[str, Any]:
+        deleted = await self.logistics_package_repository.delete(package_id)
+        if not deleted:
+            return {
+                "success": False,
+                "message": "Pacote logístico não encontrado.",
+                "error_code": "not_found",
+            }
+
+        return {
+            "success": True,
+            "message": "Pacote logístico removido com sucesso.",
+        }
+
+    async def _validate_references(
+        self, driver_id: str, collector_id: str, car_id: str
+    ) -> Dict[str, Any]:
+        driver_result = await self._fetch_active_driver(driver_id)
+        if "error" in driver_result:
+            return driver_result
+
+        collector_result = await self._fetch_active_collector(collector_id)
+        if "error" in collector_result:
+            return collector_result
+
+        car_result = await self._fetch_active_car(car_id)
+        if "error" in car_result:
+            return car_result
+
+        return {
+            "driver": driver_result["driver"],
+            "collector": collector_result["collector"],
+            "car": car_result["car"],
+        }
+
+    async def _fetch_active_driver(self, driver_id: str) -> Dict[str, Any]:
+        driver = await self.driver_repository.find_by_id(driver_id)
+        if not driver:
+            return {
+                "error": {
+                    "message": "Motorista informado não foi encontrado.",
+                    "error_code": "driver_not_found",
+                }
+            }
+
+        if (driver.status or "Ativo") != "Ativo":
+            return {
+                "error": {
+                    "message": "Motorista selecionado está inativo.",
+                    "error_code": "driver_inactive",
+                }
+            }
+
+        return {"driver": driver}
+
+    async def _fetch_active_collector(self, collector_id: str) -> Dict[str, Any]:
+        collector = await self.collector_repository.find_by_id(collector_id)
+        if not collector:
+            return {
+                "error": {
+                    "message": "Coletora informada não foi encontrada.",
+                    "error_code": "collector_not_found",
+                }
+            }
+
+        if (collector.status or "Ativo") != "Ativo":
+            return {
+                "error": {
+                    "message": "Coletora selecionada está inativa.",
+                    "error_code": "collector_inactive",
+                }
+            }
+
+        return {"collector": collector}
+
+    async def _fetch_active_car(self, car_id: str) -> Dict[str, Any]:
+        car = await self.car_repository.find_by_id(car_id)
+        if not car:
+            return {
+                "error": {
+                    "message": "Carro informado não foi encontrado.",
+                    "error_code": "car_not_found",
+                }
+            }
+
+        if (car.status or "Ativo") != "Ativo":
+            return {
+                "error": {
+                    "message": "Carro selecionado está indisponível.",
+                    "error_code": "car_inactive",
+                }
+            }
+
+        return {"car": car}
+
+    def _build_car_display_name(self, car_name: str, unidade: Optional[str]) -> str:
+        base = car_name.strip()
+        if unidade and unidade.strip():
+            return f"Carro: {base} | Unidade: {unidade.strip()}"
+        return f"Carro: {base}"
+
+    def _to_response(
+        self, package: LogisticsPackage
+    ) -> LogisticsPackageResponseDTO:
+        data = package.model_dump()
+        data["id"] = str(package.id)
+        return LogisticsPackageResponseDTO(**data)
+

--- a/backend/src/domain/entities/appointment.py
+++ b/backend/src/domain/entities/appointment.py
@@ -47,6 +47,12 @@ class Appointment(Entity):
     carro: Optional[str] = Field(
         None, description="Informações do carro utilizado"
     )
+    logistics_package_id: Optional[str] = Field(
+        None, description="ID do pacote logístico atribuído"
+    )
+    logistics_package_name: Optional[str] = Field(
+        None, description="Nome do pacote logístico selecionado"
+    )
     observacoes: Optional[str] = Field(
         None, description="Observações adicionais"
     )

--- a/backend/src/domain/entities/logistics_package.py
+++ b/backend/src/domain/entities/logistics_package.py
@@ -1,0 +1,70 @@
+"""Domain entity representing a reusable logistics package."""
+
+from typing import Optional
+
+from pydantic import Field, field_validator
+
+from src.domain.base import Entity
+
+
+class LogisticsPackage(Entity):
+    """Aggregate of car, driver and collector to speed up assignments."""
+
+    nome: str = Field(..., description="Nome descritivo do pacote logístico")
+    descricao: Optional[str] = Field(
+        None, description="Notas adicionais para identificar o pacote"
+    )
+    driver_id: str = Field(..., description="Identificador do motorista")
+    driver_nome: str = Field(..., description="Nome do motorista no momento do cadastro")
+    collector_id: str = Field(..., description="Identificador da coletora")
+    collector_nome: str = Field(
+        ..., description="Nome da coletora no momento do cadastro"
+    )
+    car_id: str = Field(..., description="Identificador do carro associado")
+    car_nome: str = Field(..., description="Nome ou apelido do carro")
+    car_unidade: Optional[str] = Field(
+        None, description="Unidade associada ao carro, quando disponível"
+    )
+    car_display_name: str = Field(
+        ..., description="Rótulo pronto para preencher o campo `carro` do agendamento"
+    )
+    status: str = Field(
+        "Ativo",
+        description="Status operacional do pacote",
+    )
+
+    @field_validator("nome")
+    @classmethod
+    def validate_nome(cls, value: str) -> str:
+        if not value or not value.strip():
+            raise ValueError("Nome do pacote é obrigatório")
+        return value.strip()
+
+    @field_validator(
+        "driver_id",
+        "driver_nome",
+        "collector_id",
+        "collector_nome",
+        "car_id",
+        "car_nome",
+        "car_display_name",
+    )
+    @classmethod
+    def validate_non_empty(cls, value: str) -> str:
+        if not value or not value.strip():
+            raise ValueError("Campo obrigatório não pode estar vazio")
+        return value.strip()
+
+    @field_validator("status")
+    @classmethod
+    def validate_status(cls, value: Optional[str]) -> str:
+        allowed = {"Ativo", "Inativo"}
+        if value is None:
+            return "Ativo"
+        normalized = value.strip().title()
+        if normalized not in allowed:
+            raise ValueError(
+                "Status inválido. Utilize 'Ativo' ou 'Inativo' para pacotes logísticos."
+            )
+        return normalized
+

--- a/backend/src/domain/repositories/logistics_package_repository_interface.py
+++ b/backend/src/domain/repositories/logistics_package_repository_interface.py
@@ -1,0 +1,39 @@
+"""Interface for logistics package repository implementations."""
+
+from abc import ABC, abstractmethod
+from typing import List, Optional
+
+from src.domain.entities.logistics_package import LogisticsPackage
+
+
+class LogisticsPackageRepositoryInterface(ABC):
+    """Repository contract for managing logistics packages."""
+
+    @abstractmethod
+    async def create(self, package: LogisticsPackage) -> LogisticsPackage:
+        """Persist a new logistics package."""
+
+    @abstractmethod
+    async def find_by_id(self, package_id: str) -> Optional[LogisticsPackage]:
+        """Retrieve a logistics package by its identifier."""
+
+    @abstractmethod
+    async def find_all(
+        self, *, status: Optional[str] = None
+    ) -> List[LogisticsPackage]:
+        """List packages, optionally filtering by status."""
+
+    @abstractmethod
+    async def update(
+        self, package_id: str, changes: dict
+    ) -> Optional[LogisticsPackage]:
+        """Apply partial changes to an existing package."""
+
+    @abstractmethod
+    async def delete(self, package_id: str) -> bool:
+        """Remove a package permanently."""
+
+    @abstractmethod
+    async def create_indexes(self) -> None:
+        """Ensure collection indexes exist."""
+

--- a/backend/src/infrastructure/container.py
+++ b/backend/src/infrastructure/container.py
@@ -16,6 +16,9 @@ from src.infrastructure.repositories.driver_repository import DriverRepository
 from src.infrastructure.repositories.user_repository import UserRepository
 from src.infrastructure.repositories.notification_repository import NotificationRepository
 from src.infrastructure.repositories.tag_repository import TagRepository
+from src.infrastructure.repositories.logistics_package_repository import (
+    LogisticsPackageRepository,
+)
 from src.infrastructure.services.redis_service import RedisService
 from src.infrastructure.services.rate_limiter import RateLimiter
 
@@ -42,6 +45,9 @@ class Container:
         self._user_repository: Optional[UserRepository] = None
         self._notification_repository: Optional[NotificationRepository] = None
         self._tag_repository: Optional[TagRepository] = None
+        self._logistics_package_repository: Optional[
+            LogisticsPackageRepository
+        ] = None
         self._redis_service: Optional[RedisService] = None
         self._rate_limiter: Optional[RateLimiter] = None
 
@@ -136,6 +142,16 @@ class Container:
         return self._collector_repository
 
     @property
+    def logistics_package_repository(self) -> LogisticsPackageRepository:
+        """Get logistics package repository instance."""
+
+        if self._logistics_package_repository is None:
+            self._logistics_package_repository = LogisticsPackageRepository(
+                self.database
+            )
+        return self._logistics_package_repository
+
+    @property
     def user_repository(self) -> UserRepository:
         """
         Get user repository instance.
@@ -214,6 +230,7 @@ class Container:
             await self.user_repository.ensure_indexes()
             await self.notification_repository.create_indexes()
             await self.tag_repository.ensure_indexes()
+            await self.logistics_package_repository.create_indexes()
             print("✅ Database indexes created")
         except Exception as e:
             print(f"❌ Failed to connect to MongoDB: {e}")
@@ -314,3 +331,9 @@ async def get_user_repository() -> UserRepository:
 async def get_tag_repository() -> TagRepository:
     """Dependency for getting tag repository instance."""
     return container.tag_repository
+
+
+async def get_logistics_package_repository() -> LogisticsPackageRepository:
+    """Dependency for getting logistics package repository instance."""
+
+    return container.logistics_package_repository

--- a/backend/src/infrastructure/repositories/logistics_package_repository.py
+++ b/backend/src/infrastructure/repositories/logistics_package_repository.py
@@ -1,0 +1,64 @@
+"""MongoDB repository for logistics packages."""
+
+from typing import Any, Dict, List, Optional
+
+from motor.motor_asyncio import AsyncIOMotorDatabase
+from pymongo import ASCENDING
+
+from src.domain.entities.logistics_package import LogisticsPackage
+from src.domain.repositories.logistics_package_repository_interface import (
+    LogisticsPackageRepositoryInterface,
+)
+
+
+class LogisticsPackageRepository(LogisticsPackageRepositoryInterface):
+    """Persist logistics packages on MongoDB."""
+
+    def __init__(self, database: AsyncIOMotorDatabase):
+        self.collection = database.logistics_packages
+
+    async def create(self, package: LogisticsPackage) -> LogisticsPackage:
+        payload = package.model_dump()
+        payload["id"] = str(payload["id"])
+        await self.collection.insert_one(payload)
+        return package
+
+    async def find_by_id(self, package_id: str) -> Optional[LogisticsPackage]:
+        doc = await self.collection.find_one({"id": package_id})
+        if not doc:
+            return None
+        doc.pop("_id", None)
+        return LogisticsPackage(**doc)
+
+    async def find_all(
+        self, *, status: Optional[str] = None
+    ) -> List[LogisticsPackage]:
+        filters: Dict[str, Any] = {}
+        if status:
+            filters["status"] = status
+
+        cursor = self.collection.find(filters).sort("nome", ASCENDING)
+        packages: List[LogisticsPackage] = []
+        async for doc in cursor:
+            doc.pop("_id", None)
+            packages.append(LogisticsPackage(**doc))
+        return packages
+
+    async def update(
+        self, package_id: str, changes: Dict[str, Any]
+    ) -> Optional[LogisticsPackage]:
+        if not changes:
+            return await self.find_by_id(package_id)
+
+        await self.collection.update_one({"id": package_id}, {"$set": changes})
+        return await self.find_by_id(package_id)
+
+    async def delete(self, package_id: str) -> bool:
+        result = await self.collection.delete_one({"id": package_id})
+        return result.deleted_count > 0
+
+    async def create_indexes(self) -> None:
+        await self.collection.create_index("id", unique=True)
+        await self.collection.create_index("nome", unique=True)
+        await self.collection.create_index("status")
+

--- a/backend/src/presentation/api/v1/endpoints/appointments.py
+++ b/backend/src/presentation/api/v1/endpoints/appointments.py
@@ -40,6 +40,7 @@ from src.infrastructure.config import Settings, get_settings
 from src.infrastructure.container import (
     get_appointment_repository,
     get_car_repository,
+    get_logistics_package_repository,
     get_tag_repository,
 )
 from src.infrastructure.repositories.appointment_repository import (
@@ -62,6 +63,7 @@ async def get_appointment_service(
         get_appointment_repository
     ),
     car_repository=Depends(get_car_repository),
+    logistics_package_repository=Depends(get_logistics_package_repository),
     tag_repository: TagRepository = Depends(get_tag_repository),
     settings: Settings = Depends(get_settings),
 ) -> AppointmentService:
@@ -92,6 +94,7 @@ async def get_appointment_service(
     return AppointmentService(
         appointment_repository,
         excel_parser,
+        logistics_package_repository=logistics_package_repository,
         tag_repository=tag_repository,
         max_tags_per_appointment=settings.max_tags_per_appointment,
     )

--- a/backend/src/presentation/api/v1/endpoints/logistics_packages.py
+++ b/backend/src/presentation/api/v1/endpoints/logistics_packages.py
@@ -1,0 +1,194 @@
+"""API endpoints for logistics packages."""
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from src.application.dtos.logistics_package_dto import (
+    LogisticsPackageCreateDTO,
+    LogisticsPackageResponseDTO,
+    LogisticsPackageUpdateDTO,
+)
+from src.application.services.logistics_package_service import (
+    LogisticsPackageService,
+)
+from src.infrastructure.container import (
+    get_car_repository,
+    get_collector_repository,
+    get_driver_repository,
+    get_logistics_package_repository,
+)
+from src.presentation.api.responses import BaseResponse, DataResponse, ListResponse
+from src.presentation.dependencies.auth import get_current_active_user
+
+router = APIRouter()
+
+
+async def get_logistics_package_service(
+    logistics_package_repository=Depends(get_logistics_package_repository),
+    driver_repository=Depends(get_driver_repository),
+    collector_repository=Depends(get_collector_repository),
+    car_repository=Depends(get_car_repository),
+) -> LogisticsPackageService:
+    """Resolve service com dependências configuradas."""
+
+    return LogisticsPackageService(
+        logistics_package_repository,
+        driver_repository,
+        collector_repository,
+        car_repository,
+    )
+
+
+@router.get(
+    "/",
+    response_model=ListResponse[LogisticsPackageResponseDTO],
+    summary="Listar pacotes logísticos",
+    description="Retorna os pacotes logísticos cadastrados com opção de filtrar por status.",
+)
+async def list_logistics_packages(
+    status_filter: Optional[str] = Query(
+        None, description="Filtrar por status (Ativo ou Inativo)"
+    ),
+    service: LogisticsPackageService = Depends(get_logistics_package_service),
+    current_user=Depends(get_current_active_user),
+) -> ListResponse[LogisticsPackageResponseDTO]:
+    """Lista pacotes logísticos."""
+
+    result = await service.list_packages(status=status_filter)
+    packages = result.get("packages", [])
+    total = len(packages)
+
+    return ListResponse(
+        success=True,
+        message=result.get("message"),
+        data=packages,
+        total=total,
+        page=1,
+        per_page=max(total, 1),
+        pages=1,
+    )
+
+
+@router.get(
+    "/active",
+    response_model=ListResponse[LogisticsPackageResponseDTO],
+    summary="Listar pacotes logísticos ativos",
+    description="Retorna apenas os pacotes com status Ativo.",
+)
+async def list_active_logistics_packages(
+    service: LogisticsPackageService = Depends(get_logistics_package_service),
+    current_user=Depends(get_current_active_user),
+) -> ListResponse[LogisticsPackageResponseDTO]:
+    """Lista apenas pacotes ativos."""
+
+    result = await service.list_active_packages()
+    packages = result.get("packages", [])
+    total = len(packages)
+
+    return ListResponse(
+        success=True,
+        message=result.get("message"),
+        data=packages,
+        total=total,
+        page=1,
+        per_page=max(total, 1),
+        pages=1,
+    )
+
+
+@router.get(
+    "/{package_id}",
+    response_model=DataResponse[LogisticsPackageResponseDTO],
+    summary="Obter pacote logístico",
+)
+async def get_logistics_package(
+    package_id: str,
+    service: LogisticsPackageService = Depends(get_logistics_package_service),
+    current_user=Depends(get_current_active_user),
+) -> DataResponse[LogisticsPackageResponseDTO]:
+    """Recupera um pacote específico."""
+
+    result = await service.get_package(package_id)
+    if not result["success"]:
+        raise HTTPException(status_code=404, detail=result["message"])
+
+    return DataResponse(
+        success=True,
+        message=result.get("message"),
+        data=result["package"],
+    )
+
+
+@router.post(
+    "/",
+    response_model=DataResponse[LogisticsPackageResponseDTO],
+    status_code=status.HTTP_201_CREATED,
+    summary="Criar pacote logístico",
+)
+async def create_logistics_package(
+    package_data: LogisticsPackageCreateDTO,
+    service: LogisticsPackageService = Depends(get_logistics_package_service),
+    current_user=Depends(get_current_active_user),
+) -> DataResponse[LogisticsPackageResponseDTO]:
+    """Cria um novo pacote logístico."""
+
+    result = await service.create_package(package_data)
+    if not result["success"]:
+        raise HTTPException(
+            status_code=400,
+            detail=result.get("message", "Não foi possível criar o pacote."),
+        )
+
+    return DataResponse(
+        success=True,
+        message="Pacote logístico criado com sucesso.",
+        data=result["package"],
+    )
+
+
+@router.patch(
+    "/{package_id}",
+    response_model=DataResponse[LogisticsPackageResponseDTO],
+    summary="Atualizar pacote logístico",
+)
+async def update_logistics_package(
+    package_id: str,
+    update_data: LogisticsPackageUpdateDTO,
+    service: LogisticsPackageService = Depends(get_logistics_package_service),
+    current_user=Depends(get_current_active_user),
+) -> DataResponse[LogisticsPackageResponseDTO]:
+    """Atualiza informações de um pacote logístico."""
+
+    result = await service.update_package(package_id, update_data)
+    if not result["success"]:
+        error_code = result.get("error_code", "validation")
+        status_code_value = 404 if error_code == "not_found" else 400
+        raise HTTPException(status_code=status_code_value, detail=result["message"])
+
+    return DataResponse(
+        success=True,
+        message=result.get("message", "Pacote logístico atualizado."),
+        data=result["package"],
+    )
+
+
+@router.delete(
+    "/{package_id}",
+    response_model=BaseResponse,
+    summary="Remover pacote logístico",
+    status_code=status.HTTP_200_OK,
+)
+async def delete_logistics_package(
+    package_id: str,
+    service: LogisticsPackageService = Depends(get_logistics_package_service),
+    current_user=Depends(get_current_active_user),
+) -> BaseResponse:
+    """Remove um pacote logístico."""
+
+    result = await service.delete_package(package_id)
+    if not result["success"]:
+        raise HTTPException(status_code=404, detail=result["message"])
+
+    return BaseResponse(success=True, message=result["message"])
+

--- a/backend/src/presentation/api/v1/router.py
+++ b/backend/src/presentation/api/v1/router.py
@@ -16,6 +16,7 @@ from src.presentation.api.v1.endpoints import (
     cars,
     collectors,
     drivers,
+    logistics_packages,
     notifications,
     reports,
     tags,
@@ -54,6 +55,12 @@ api_v1_router.include_router(
 api_v1_router.include_router(cars.router, prefix="/cars", tags=["Cars"])
 
 api_v1_router.include_router(
+    logistics_packages.router,
+    prefix="/logistics-packages",
+    tags=["Logistics Packages"],
+)
+
+api_v1_router.include_router(
     reports.router, prefix="/reports", tags=["Reports"]
 )
 
@@ -79,6 +86,7 @@ async def api_v1_root() -> dict[str, Any]:
             "drivers": f"{settings.api_v1_prefix}/drivers",
             "collectors": f"{settings.api_v1_prefix}/collectors",
             "cars": f"{settings.api_v1_prefix}/cars",
+            "logistics_packages": f"{settings.api_v1_prefix}/logistics-packages",
             "reports": f"{settings.api_v1_prefix}/reports",
             "notifications": f"{settings.api_v1_prefix}/notifications",
         },

--- a/backend/tests/test_appointment_api.py
+++ b/backend/tests/test_appointment_api.py
@@ -218,8 +218,8 @@ def test_get_appointment_not_found(client: TestClient) -> None:
         app.dependency_overrides.pop(get_appointment_service, None)
 
     assert response.status_code == 404
-    detail = response.json()
-    assert detail["detail"] == "Agendamento não encontrado"
+    error = response.json()
+    assert error["message"] == "Agendamento não encontrado"
 
 
 def test_partial_update_appointment_success(client: TestClient) -> None:
@@ -290,6 +290,7 @@ def test_partial_update_updates_confirmation_channel(client: TestClient) -> None
     service_mock.update_appointment.assert_awaited_once_with(
         appointment_id,
         AppointmentFullUpdateDTO(canal_confirmacao="Telefone"),
+        updated_by="Usuário Teste",
     )
 
 
@@ -318,8 +319,8 @@ def test_partial_update_appointment_validation_error(client: TestClient) -> None
         app.dependency_overrides.pop(get_appointment_service, None)
 
     assert response.status_code == 400
-    detail = response.json()
-    assert detail["detail"] == "Dados inválidos"
+    error = response.json()
+    assert error["message"] == "Dados inválidos"
 
 
 def test_partial_update_appointment_not_found(client: TestClient) -> None:
@@ -347,5 +348,5 @@ def test_partial_update_appointment_not_found(client: TestClient) -> None:
         app.dependency_overrides.pop(get_appointment_service, None)
 
     assert response.status_code == 404
-    detail = response.json()
-    assert detail["detail"] == "Agendamento não encontrado"
+    error = response.json()
+    assert error["message"] == "Agendamento não encontrado"

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -18,6 +18,7 @@ from src.infrastructure.config import Settings
 def mock_user_repository():
     """Mock user repository for testing."""
     repository = AsyncMock()
+    repository.get_inactive_by_email.return_value = None
     return repository
 
 

--- a/backend/tests/test_logistics_package_service.py
+++ b/backend/tests/test_logistics_package_service.py
@@ -1,0 +1,276 @@
+"""Unit tests for logistics package service."""
+
+from types import SimpleNamespace
+from uuid import uuid4
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.application.dtos.logistics_package_dto import (
+    LogisticsPackageCreateDTO,
+    LogisticsPackageUpdateDTO,
+)
+from src.application.services.logistics_package_service import (
+    LogisticsPackageService,
+)
+from src.domain.entities.logistics_package import LogisticsPackage
+
+
+def _build_service() -> LogisticsPackageService:
+    """Create service with async repository stubs."""
+
+    logistics_repo = AsyncMock()
+    driver_repo = AsyncMock()
+    collector_repo = AsyncMock()
+    car_repo = AsyncMock()
+
+    service = LogisticsPackageService(
+        logistics_package_repository=logistics_repo,
+        driver_repository=driver_repo,
+        collector_repository=collector_repo,
+        car_repository=car_repo,
+    )
+
+    return service
+
+
+def _active_driver() -> SimpleNamespace:
+    return SimpleNamespace(
+        id=uuid4(), nome_completo="João Motorista", status="Ativo"
+    )
+
+
+def _active_collector() -> SimpleNamespace:
+    return SimpleNamespace(
+        id=uuid4(), nome_completo="Maria Coletora", status="Ativo"
+    )
+
+
+def _active_car() -> SimpleNamespace:
+    return SimpleNamespace(
+        id=uuid4(), nome="Kombi Azul", unidade="UND-01", status="Ativo"
+    )
+
+
+def _package_from_refs(
+    driver: SimpleNamespace,
+    collector: SimpleNamespace,
+    car: SimpleNamespace,
+) -> LogisticsPackage:
+    return LogisticsPackage(
+        nome="Combo Manhã",
+        descricao=None,
+        driver_id=str(driver.id),
+        driver_nome=driver.nome_completo,
+        collector_id=str(collector.id),
+        collector_nome=collector.nome_completo,
+        car_id=str(car.id),
+        car_nome=car.nome,
+        car_unidade=car.unidade,
+        car_display_name=f"Carro: {car.nome} | Unidade: {car.unidade}",
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_packages_returns_serialized_objects() -> None:
+    service = _build_service()
+    driver = _active_driver()
+    collector = _active_collector()
+    car = _active_car()
+    package = _package_from_refs(driver, collector, car)
+    service.logistics_package_repository.find_all.return_value = [package]
+
+    result = await service.list_packages()
+
+    assert result["success"] is True
+    assert len(result["packages"]) == 1
+    service.logistics_package_repository.find_all.assert_awaited_once_with(
+        status=None
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_active_packages_filters_by_status() -> None:
+    service = _build_service()
+    service.logistics_package_repository.find_all.return_value = []
+
+    await service.list_active_packages()
+
+    service.logistics_package_repository.find_all.assert_awaited_once_with(
+        status="Ativo"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_package_not_found() -> None:
+    service = _build_service()
+    service.logistics_package_repository.find_by_id.return_value = None
+
+    result = await service.get_package("missing-id")
+
+    assert result["success"] is False
+    assert result["error_code"] == "not_found"
+
+
+@pytest.mark.asyncio
+async def test_create_package_success() -> None:
+    service = _build_service()
+    driver = _active_driver()
+    collector = _active_collector()
+    car = _active_car()
+
+    service.driver_repository.find_by_id.return_value = driver
+    service.collector_repository.find_by_id.return_value = collector
+    service.car_repository.find_by_id.return_value = car
+
+    created_package = _package_from_refs(driver, collector, car)
+    service.logistics_package_repository.create.return_value = created_package
+
+    dto = LogisticsPackageCreateDTO(
+        nome="Combo Manhã",
+        descricao="",
+        driver_id=str(driver.id),
+        collector_id=str(collector.id),
+        car_id=str(car.id),
+    )
+
+    result = await service.create_package(dto)
+
+    assert result["success"] is True
+    service.logistics_package_repository.create.assert_awaited_once()
+    payload = service.logistics_package_repository.create.await_args.args[0]
+    assert payload.driver_nome == "João Motorista"
+    assert payload.car_display_name.endswith("UND-01")
+
+
+@pytest.mark.asyncio
+async def test_create_package_driver_missing() -> None:
+    service = _build_service()
+    service.driver_repository.find_by_id.return_value = None
+
+    dto = LogisticsPackageCreateDTO(
+        nome="Combo Manhã",
+        descricao=None,
+        driver_id="unknown",
+        collector_id="collector",
+        car_id="car",
+    )
+
+    result = await service.create_package(dto)
+
+    assert "error" in result
+    assert result["error"]["error_code"] == "driver_not_found"
+
+
+@pytest.mark.asyncio
+async def test_update_package_no_changes_returns_original() -> None:
+    service = _build_service()
+    driver = _active_driver()
+    collector = _active_collector()
+    car = _active_car()
+    existing = _package_from_refs(driver, collector, car)
+    service.logistics_package_repository.find_by_id.return_value = existing
+
+    result = await service.update_package("package-id", LogisticsPackageUpdateDTO())
+
+    assert result["success"] is True
+    assert result["message"] == "Nenhuma alteração realizada."
+    service.logistics_package_repository.update.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_update_package_rejects_invalid_status() -> None:
+    service = _build_service()
+    driver = _active_driver()
+    collector = _active_collector()
+    car = _active_car()
+    existing = _package_from_refs(driver, collector, car)
+    service.logistics_package_repository.find_by_id.return_value = existing
+
+    result = await service.update_package(
+        "package-id", LogisticsPackageUpdateDTO(status="Pausado")
+    )
+
+    assert result["success"] is False
+    assert result["error_code"] == "validation"
+    service.logistics_package_repository.update.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_update_package_updates_references() -> None:
+    service = _build_service()
+    original_driver = _active_driver()
+    collector = _active_collector()
+    car = _active_car()
+    existing = _package_from_refs(original_driver, collector, car)
+    service.logistics_package_repository.find_by_id.return_value = existing
+
+    new_driver = SimpleNamespace(
+        id=uuid4(), nome_completo="Carlos Motorista", status="Ativo"
+    )
+    service.driver_repository.find_by_id.return_value = new_driver
+    updated_entity = existing.model_copy(update={
+        "driver_id": str(new_driver.id),
+        "driver_nome": new_driver.nome_completo,
+    })
+    service.logistics_package_repository.update.return_value = updated_entity
+
+    result = await service.update_package(
+        "package-id", LogisticsPackageUpdateDTO(driver_id=str(new_driver.id))
+    )
+
+    assert result["success"] is True
+    service.logistics_package_repository.update.assert_awaited_once()
+    updates = service.logistics_package_repository.update.await_args.args[1]
+    assert updates["driver_id"] == str(new_driver.id)
+    assert updates["driver_nome"] == "Carlos Motorista"
+
+
+@pytest.mark.asyncio
+async def test_update_package_returns_driver_lookup_error() -> None:
+    service = _build_service()
+    driver = _active_driver()
+    collector = _active_collector()
+    car = _active_car()
+    existing = _package_from_refs(driver, collector, car)
+    service.logistics_package_repository.find_by_id.return_value = existing
+    service.driver_repository.find_by_id.return_value = None
+
+    result = await service.update_package(
+        "package-id", LogisticsPackageUpdateDTO(driver_id="unknown")
+    )
+
+    assert "error" in result
+    assert result["error"]["error_code"] == "driver_not_found"
+
+
+@pytest.mark.asyncio
+async def test_delete_package_success() -> None:
+    service = _build_service()
+    service.logistics_package_repository.delete.return_value = True
+
+    result = await service.delete_package("package-id")
+
+    assert result["success"] is True
+    service.logistics_package_repository.delete.assert_awaited_once_with(
+        "package-id"
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_package_not_found() -> None:
+    service = _build_service()
+    service.logistics_package_repository.delete.return_value = False
+
+    result = await service.delete_package("missing")
+
+    assert result["success"] is False
+    assert result["error_code"] == "not_found"
+
+
+def test_build_car_display_name_without_unit() -> None:
+    service = _build_service()
+
+    label = service._build_car_display_name("Kombi Azul", unidade=None)
+
+    assert label == "Carro: Kombi Azul"

--- a/docs/logistics_packages_plan.md
+++ b/docs/logistics_packages_plan.md
@@ -1,0 +1,25 @@
+# Plano de Pacotes Logísticos
+
+## Visão Geral
+- Introduzir uma entidade de **pacote logístico** que agrupa carro, motorista e coletora em uma única combinação reutilizável.
+- Permitir que agendamentos novos ou existentes selecionem um pacote para preencher automaticamente os campos logísticos.
+- Disponibilizar uma tela administrativa simples para cadastrar e acompanhar os pacotes.
+
+## Trilhas de Trabalho
+1. **Back-end**
+   - [x] Modelar entidade, repositório e serviço para pacotes logísticos.
+   - [x] Expor endpoints REST para CRUD básico e listagem de ativos.
+   - [x] Ajustar o serviço de agendamentos para aceitar `logistics_package_id` e preencher trio automaticamente.
+2. **Front-end**
+   - [x] Disponibilizar cadastro e listagem de pacotes logísticos.
+   - [x] Permitir seleção de pacote na criação de agendamentos.
+   - [x] Permitir seleção/alteração de pacote nos detalhes do agendamento, mantendo possibilidade de personalização manual.
+3. **Experiência do Usuário**
+   - [x] Exibir nome do pacote e trio designado em cartões/tabelas de agendamento.
+   - [ ] Construir painel de disponibilidade cruzando agenda e pacotes (próxima etapa).
+
+## Progresso
+- Entidade, serviço e API REST implementados no back-end, com validações de integridade dos vínculos.
+- Tela de "Pacotes Logísticos" disponível no menu principal para criação, edição de status e visualização.
+- Fluxos de criação e edição de agendamento recebem o pacote e preenchem automaticamente motorista, coletora e carro.
+- Próxima prioridade: evoluir o painel de disponibilidade para suportar a visualização combinada (em aberto neste plano).

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import { UsersPage } from './pages/UsersPage';
 import { PublicRegister } from './pages/PublicRegister';
 import { VerifyEmail } from './pages/VerifyEmail';
 import { TagsPage } from './pages/TagsPage';
+import { LogisticsPackagesPage } from './pages/LogisticsPackagesPage';
 
 // Create a client
 const queryClient = new QueryClient({
@@ -43,6 +44,8 @@ function Shell() {
         return <CollectorsPage />;
       case 'cars':
         return <CarsPage />;
+      case 'logistics':
+        return <LogisticsPackagesPage />;
       case 'users':
         return <UsersPage />;
       case 'tags':

--- a/frontend/src/components/AppointmentCalendarView.tsx
+++ b/frontend/src/components/AppointmentCalendarView.tsx
@@ -18,11 +18,11 @@ export const AppointmentCalendarView: React.FC<CalendarViewProps> = ({
   onDateSelect,
   onMonthChange,
   onAppointmentStatusChange,
-  onAppointmentDriverChange,
-  onAppointmentCollectorChange,
+  onAppointmentLogisticsPackageChange,
   onAppointmentDelete,
   drivers = [],
   collectors = [],
+  logisticsPackages = [],
   isLoading = false,
 }) => {
   const [modalDate, setModalDate] = useState<Date | null>(null);
@@ -159,11 +159,11 @@ export const AppointmentCalendarView: React.FC<CalendarViewProps> = ({
           date={modalDate}
           appointments={modalAppointments}
           onStatusChange={onAppointmentStatusChange}
-          onDriverChange={onAppointmentDriverChange}
-          onCollectorChange={onAppointmentCollectorChange}
+          onLogisticsPackageChange={onAppointmentLogisticsPackageChange}
           onDelete={onAppointmentDelete}
           drivers={drivers}
           collectors={collectors}
+          logisticsPackages={logisticsPackages}
         />
       )}
     </div>

--- a/frontend/src/components/AppointmentCard.tsx
+++ b/frontend/src/components/AppointmentCard.tsx
@@ -179,6 +179,12 @@ export const AppointmentCard: React.FC<AppointmentCardProps> = ({
       {/* Body */}
       <div className={`mt-4 grid grid-cols-1 gap-4 ${compact ? '' : 'md:grid-cols-2'}`}>
         <div className="space-y-4">
+          {appointment.logistics_package_name && (
+            <div>
+              <p className={detailLabelClass}>Pacote logístico</p>
+              <p className={detailValueClass}>{appointment.logistics_package_name}</p>
+            </div>
+          )}
           <div>
             <p className={detailLabelClass}>Data e horário</p>
             <div className={`mt-1 flex flex-wrap items-center gap-2 ${detailValueClass}`}>

--- a/frontend/src/components/AppointmentCardList.tsx
+++ b/frontend/src/components/AppointmentCardList.tsx
@@ -3,16 +3,20 @@ import { AppointmentCard } from './AppointmentCard';
 import type { AppointmentViewModel } from '../types/appointment';
 import type { ActiveDriver } from '../types/driver';
 import type { ActiveCollector } from '../types/collector';
+import type { LogisticsPackage } from '../types/logistics-package';
 import { useResponsiveLayout } from '../hooks/useResponsiveLayout';
 
 interface AppointmentCardListProps {
   appointments: AppointmentViewModel[];
   drivers: ActiveDriver[];
   collectors?: ActiveCollector[];
+  logisticsPackages?: LogisticsPackage[];
   isLoading?: boolean;
   onStatusChange: (id: string, status: string) => void;
-  onDriverChange: (appointmentId: string, driverId: string) => void;
-  onCollectorChange?: (appointmentId: string, collectorId: string) => void;
+  onLogisticsPackageChange?: (
+    appointmentId: string,
+    logisticsPackageId: string | null,
+  ) => void;
   onDelete: (id: string) => void;
   onSelect?: (id: string) => void;
 }
@@ -39,10 +43,10 @@ export const AppointmentCardList: React.FC<AppointmentCardListProps> = ({
   appointments,
   drivers,
   collectors = [],
+  logisticsPackages = [],
   isLoading = false,
   onStatusChange,
-  onDriverChange,
-  onCollectorChange,
+  onLogisticsPackageChange,
   onDelete,
   onSelect,
 }) => {
@@ -88,9 +92,9 @@ export const AppointmentCardList: React.FC<AppointmentCardListProps> = ({
           appointment={appointment}
           drivers={drivers}
           collectors={collectors}
+          logisticsPackages={logisticsPackages}
           onStatusChange={onStatusChange}
-          onDriverChange={onDriverChange}
-          onCollectorChange={onCollectorChange}
+          onLogisticsPackageChange={onLogisticsPackageChange}
           onDelete={onDelete}
           compact={isMobile}
           onSelect={onSelect}

--- a/frontend/src/components/AppointmentTable.tsx
+++ b/frontend/src/components/AppointmentTable.tsx
@@ -201,6 +201,11 @@ export const AppointmentTable: React.FC<AppointmentTableProps> = ({
 
           return (
             <div className="space-y-3 text-sm text-gray-600">
+              {appointment.logistics_package_name && (
+                <div className="rounded-md border border-blue-100 bg-blue-50 px-2 py-1 text-xs text-blue-700">
+                  Pacote: {appointment.logistics_package_name}
+                </div>
+              )}
               <div>
                 <span className="text-xs font-medium uppercase tracking-wide text-gray-500">Motorista</span>
                 <select

--- a/frontend/src/components/AppointmentTable.tsx
+++ b/frontend/src/components/AppointmentTable.tsx
@@ -12,16 +12,20 @@ import React from 'react';
 import type { AppointmentViewModel } from '../types/appointment.ts';
 import type { ActiveCollector } from '../types/collector.ts';
 import type { ActiveDriver } from '../types/driver.ts';
+import type { LogisticsPackage } from '../types/logistics-package';
 import { TagBadge } from './tags/TagBadge';
 
 interface AppointmentTableProps {
   appointments: AppointmentViewModel[];
   drivers?: ActiveDriver[];
   collectors?: ActiveCollector[];
+  logisticsPackages?: LogisticsPackage[];
   isLoading?: boolean;
   onStatusChange?: (id: string, status: string) => void;
-  onDriverChange?: (appointmentId: string, driverId: string) => void;
-  onCollectorChange?: (appointmentId: string, collectorId: string) => void;
+  onLogisticsPackageChange?: (
+    appointmentId: string,
+    logisticsPackageId: string | null,
+  ) => void;
   onDelete?: (id: string) => void;
   onSelect?: (appointmentId: string) => void;
 }
@@ -54,16 +58,28 @@ export const AppointmentTable: React.FC<AppointmentTableProps> = ({
   appointments,
   drivers = [],
   collectors = [],
+  logisticsPackages = [],
   isLoading = false,
   onStatusChange,
-  onDriverChange,
-  onCollectorChange,
+  onLogisticsPackageChange,
   onDelete,
   onSelect,
 }) => {
   const [sorting, setSorting] = React.useState<SortingState>([
     { id: 'data_agendamento', desc: false },
   ]);
+
+  const resolveAssignedName = (
+    assignedId: string | undefined | null,
+    people: Array<{ id: string; nome_completo: string }>,
+  ): string => {
+    if (!assignedId) {
+      return 'Não atribuído';
+    }
+
+    const match = people.find(person => person.id === assignedId);
+    return match?.nome_completo ?? 'Não atribuído';
+  };
 
   const columns = React.useMemo<ColumnDef<AppointmentViewModel>[]>(
     () => [
@@ -198,44 +214,50 @@ export const AppointmentTable: React.FC<AppointmentTableProps> = ({
           const carroInfo = appointment.carro || '';
           const carroMatch = carroInfo.match(/Carro:\s*([^|]+)/);
           const carro = carroMatch ? carroMatch[1].trim() : carroInfo;
+          const driverName = resolveAssignedName(appointment.driver_id, drivers);
+          const collectorName = resolveAssignedName(appointment.collector_id, collectors);
 
           return (
             <div className="space-y-3 text-sm text-gray-600">
-              {appointment.logistics_package_name && (
-                <div className="rounded-md border border-blue-100 bg-blue-50 px-2 py-1 text-xs text-blue-700">
-                  Pacote: {appointment.logistics_package_name}
-                </div>
-              )}
-              <div>
-                <span className="text-xs font-medium uppercase tracking-wide text-gray-500">Motorista</span>
-                <select
-                  value={appointment.driver_id || ''}
-                  onChange={(e) => onDriverChange?.(appointment.id, e.target.value)}
-                  className="mt-1 w-full rounded-md border border-gray-300 bg-white px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-                >
-                  <option value="">Selecionar motorista</option>
-                  {drivers.map((driver) => (
-                    <option key={driver.id} value={driver.id}>
-                      {driver.nome_completo}
-                    </option>
-                  ))}
-                </select>
+              <div className="space-y-1">
+                <span className="text-xs font-medium uppercase tracking-wide text-gray-500">Pacote logístico</span>
+                {onLogisticsPackageChange ? (
+                  <select
+                    value={appointment.logistics_package_id || ''}
+                    onChange={(event) =>
+                      onLogisticsPackageChange(
+                        appointment.id,
+                        event.target.value ? event.target.value : null,
+                      )
+                    }
+                    className="w-full rounded-md border border-gray-300 bg-white px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  >
+                    <option value="">Sem pacote logístico</option>
+                    {logisticsPackages.map(logisticsPackage => (
+                      <option key={logisticsPackage.id} value={logisticsPackage.id}>
+                        {logisticsPackage.nome}
+                      </option>
+                    ))}
+                  </select>
+                ) : (
+                  <div className="rounded-md border border-blue-100 bg-blue-50 px-2 py-1 text-xs text-blue-700">
+                    {appointment.logistics_package_name || 'Sem pacote atribuído'}
+                  </div>
+                )}
               </div>
 
               <div>
                 <span className="text-xs font-medium uppercase tracking-wide text-gray-500">Coletora</span>
-                <select
-                  value={appointment.collector_id || ''}
-                  onChange={(e) => onCollectorChange?.(appointment.id, e.target.value)}
-                  className="mt-1 w-full rounded-md border border-gray-300 bg-white px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-purple-500"
-                >
-                  <option value="">Selecionar coletora</option>
-                  {collectors.map((collector) => (
-                    <option key={collector.id} value={collector.id}>
-                      {collector.nome_completo}
-                    </option>
-                  ))}
-                </select>
+                <div className="mt-1 rounded-md border border-gray-200 bg-gray-50 px-2 py-1 text-xs text-gray-700">
+                  {collectorName}
+                </div>
+              </div>
+
+              <div>
+                <span className="text-xs font-medium uppercase tracking-wide text-gray-500">Motorista</span>
+                <div className="mt-1 rounded-md border border-gray-200 bg-gray-50 px-2 py-1 text-xs text-gray-700">
+                  {driverName}
+                </div>
               </div>
 
               {carro && (
@@ -268,7 +290,7 @@ export const AppointmentTable: React.FC<AppointmentTableProps> = ({
         ),
       },
     ],
-    [collectors, drivers, onCollectorChange, onDelete, onDriverChange, onSelect, onStatusChange]
+    [collectors, drivers, logisticsPackages, onDelete, onLogisticsPackageChange, onSelect, onStatusChange]
   );
 
   const table = useReactTable({

--- a/frontend/src/components/CalendarDayModal.tsx
+++ b/frontend/src/components/CalendarDayModal.tsx
@@ -15,11 +15,11 @@ export const CalendarDayModal: React.FC<DayModalProps> = ({
   date,
   appointments,
   onStatusChange,
-  onDriverChange,
-  onCollectorChange,
+  onLogisticsPackageChange,
   onDelete,
   drivers = [],
   collectors = [],
+  logisticsPackages = [],
 }) => {
   const dateString = formatCalendarDate(date, 'EEEE, dd \'de\' MMMM \'de\' yyyy');
   const hasAppointments = appointments.length > 0;
@@ -95,8 +95,8 @@ export const CalendarDayModal: React.FC<DayModalProps> = ({
                           drivers={drivers as any[]}
                           collectors={collectors as any[]}
                           onStatusChange={onStatusChange || (() => {})}
-                          onDriverChange={onDriverChange || (() => {})}
-                          onCollectorChange={onCollectorChange || (() => {})}
+                          logisticsPackages={logisticsPackages}
+                          onLogisticsPackageChange={onLogisticsPackageChange}
                           onDelete={onDelete || (() => {})}
                           compact={true}
                         />

--- a/frontend/src/components/CollectorAgendaView.tsx
+++ b/frontend/src/components/CollectorAgendaView.tsx
@@ -8,6 +8,7 @@ import React, { useMemo } from 'react';
 import type { AppointmentViewModel } from '../types/appointment';
 import type { ActiveCollector } from '../types/collector';
 import type { ActiveDriver } from '../types/driver';
+import type { LogisticsPackage } from '../types/logistics-package';
 import { AppointmentCard } from './AppointmentCard';
 
 interface CollectorAgendaViewProps {
@@ -17,10 +18,13 @@ interface CollectorAgendaViewProps {
   selectedDate: Date;
   isLoading: boolean;
   onAppointmentStatusChange: (id: string, status: string) => void;
-  onAppointmentDriverChange: (appointmentId: string, driverId: string) => void;
-  onAppointmentCollectorChange: (appointmentId: string, collectorId: string) => void;
+  onAppointmentLogisticsPackageChange?: (
+    appointmentId: string,
+    logisticsPackageId: string | null,
+  ) => void;
   onAppointmentDelete: (id: string) => void;
   onDateChange?: (date: Date) => void;
+  logisticsPackages?: LogisticsPackage[];
 }
 
 interface CollectorAppointments {
@@ -55,10 +59,10 @@ export const CollectorAgendaView: React.FC<CollectorAgendaViewProps> = ({
   selectedDate,
   isLoading,
   onAppointmentStatusChange,
-  onAppointmentDriverChange,
-  onAppointmentCollectorChange,
+  onAppointmentLogisticsPackageChange,
   onAppointmentDelete,
   onDateChange,
+  logisticsPackages = [],
 }) => {
   const selectedDateStr = useMemo(() => {
     return selectedDate.toISOString().split('T')[0];
@@ -426,9 +430,9 @@ export const CollectorAgendaView: React.FC<CollectorAgendaViewProps> = ({
                   appointment={appointment}
                   drivers={drivers}
                   collectors={collectors}
+                  logisticsPackages={logisticsPackages}
                   onStatusChange={onAppointmentStatusChange}
-                  onDriverChange={onAppointmentDriverChange}
-                  onCollectorChange={onAppointmentCollectorChange}
+                  onLogisticsPackageChange={onAppointmentLogisticsPackageChange}
                   onDelete={onAppointmentDelete}
                   compact={true}
                 />

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -10,6 +10,7 @@ import {
   SunIcon,
   TruckIcon,
   UserIcon,
+  Squares2X2Icon,
 } from '@heroicons/react/24/outline';
 import React from 'react';
 import { useAuth } from '../hooks/useAuth';
@@ -56,6 +57,13 @@ const navigationItems = [
     name: 'Carros',
     icon: TruckIcon,
     description: 'Cadastrar e gerenciar carros',
+    adminOnly: false,
+  },
+  {
+    id: 'logistics',
+    name: 'Pacotes Logísticos',
+    icon: Squares2X2Icon,
+    description: 'Combinar carro, motorista e coletora em um só clique',
     adminOnly: false,
   },
   {

--- a/frontend/src/pages/AppointmentsPage.tsx
+++ b/frontend/src/pages/AppointmentsPage.tsx
@@ -267,6 +267,21 @@ export const AppointmentsPage: React.FC = () => {
     }
   };
 
+  const handleLogisticsPackageChange = async (
+    appointmentId: string,
+    logisticsPackageId: string | null,
+  ) => {
+    try {
+      await appointmentAPI.updateAppointment(appointmentId, {
+        logistics_package_id: logisticsPackageId,
+      });
+      queryClient.invalidateQueries({ queryKey: ['appointments'] });
+    } catch (error) {
+      console.error('Error updating appointment logistics package:', error);
+      showToastError('Não foi possível atualizar o pacote logístico.');
+    }
+  };
+
   return (
     <>
       <ToastContainer toasts={toasts} onRemove={removeToast} />
@@ -422,10 +437,10 @@ export const AppointmentsPage: React.FC = () => {
               appointments={filteredAppointments}
               drivers={driversData?.drivers || []}
               collectors={collectorsData?.collectors || []}
+              logisticsPackages={logisticsPackagesData?.data || []}
               isLoading={isLoadingAppointments}
               onStatusChange={handleStatusChange}
-              onDriverChange={handleDriverChange}
-              onCollectorChange={handleCollectorChange}
+              onLogisticsPackageChange={handleLogisticsPackageChange}
               onDelete={handleDelete}
               onSelect={openAppointmentDetails}
             />
@@ -453,11 +468,11 @@ export const AppointmentsPage: React.FC = () => {
               onDateSelect={setSelectedDate}
               onMonthChange={setCurrentCalendarDate}
               onAppointmentStatusChange={handleStatusChange}
-              onAppointmentDriverChange={handleDriverChange}
-              onAppointmentCollectorChange={handleCollectorChange}
+              onAppointmentLogisticsPackageChange={handleLogisticsPackageChange}
               onAppointmentDelete={handleDelete}
               drivers={driversData?.drivers || []}
               collectors={collectorsData?.collectors || []}
+              logisticsPackages={logisticsPackagesData?.data || []}
               isLoading={isLoadingAppointments}
             />
           )}
@@ -487,10 +502,10 @@ export const AppointmentsPage: React.FC = () => {
                 selectedDate={selectedAgendaDate}
                 isLoading={isLoadingAppointments}
                 onAppointmentStatusChange={handleStatusChange}
-                onAppointmentDriverChange={handleDriverChange}
-                onAppointmentCollectorChange={handleCollectorChange}
+                onAppointmentLogisticsPackageChange={handleLogisticsPackageChange}
                 onAppointmentDelete={handleDelete}
                 onDateChange={setSelectedAgendaDate}
+                logisticsPackages={logisticsPackagesData?.data || []}
               />
             </div>
           )}

--- a/frontend/src/pages/AppointmentsPage.tsx
+++ b/frontend/src/pages/AppointmentsPage.tsx
@@ -18,7 +18,7 @@ import { ToastContainer } from '../components/ui/Toast';
 import { ViewModeToggle, type ViewMode } from '../components/ViewModeToggle';
 import { AppointmentTable } from '../components/AppointmentTable';
 import { AppointmentKpiCards } from '../components/AppointmentKpiCards';
-import { appointmentAPI, collectorAPI, driverAPI, tagAPI } from '../services/api';
+import { appointmentAPI, collectorAPI, driverAPI, logisticsPackageAPI, tagAPI } from '../services/api';
 import { useToast } from '../hooks/useToast';
 import type {
   AppointmentCreateRequest,
@@ -90,6 +90,13 @@ export const AppointmentsPage: React.FC = () => {
     queryKey: ['activeCollectors'],
     queryFn: () => collectorAPI.getActiveCollectors(),
     refetchOnWindowFocus: false,
+  });
+
+  const { data: logisticsPackagesData } = useQuery({
+    queryKey: ['activeLogisticsPackages'],
+    queryFn: () => logisticsPackageAPI.listActivePackages(),
+    refetchOnWindowFocus: false,
+    staleTime: 5 * 60 * 1000,
   });
 
   const { data: tagsData } = useQuery({
@@ -275,6 +282,7 @@ export const AppointmentsPage: React.FC = () => {
         collectors={collectorsData?.collectors || []}
         tags={tagsData?.data ?? []}
         maxTags={maxTagsPerAppointment}
+        logisticsPackages={logisticsPackagesData?.data ?? []}
       />
 
       <AppointmentDetailsModal
@@ -288,6 +296,7 @@ export const AppointmentsPage: React.FC = () => {
         maxTags={maxTagsPerAppointment}
         onEditSuccess={showToastSuccess}
         onEditError={showToastError}
+        logisticsPackages={logisticsPackagesData?.data ?? []}
       />
 
       <div className="space-y-6">

--- a/frontend/src/pages/AppointmentsPage.tsx
+++ b/frontend/src/pages/AppointmentsPage.tsx
@@ -451,10 +451,10 @@ export const AppointmentsPage: React.FC = () => {
               appointments={filteredAppointments}
               drivers={driversData?.drivers || []}
               collectors={collectorsData?.collectors || []}
+              logisticsPackages={logisticsPackagesData?.data || []}
               isLoading={isLoadingAppointments}
               onStatusChange={handleStatusChange}
-              onDriverChange={handleDriverChange}
-              onCollectorChange={handleCollectorChange}
+              onLogisticsPackageChange={handleLogisticsPackageChange}
               onDelete={handleDelete}
               onSelect={openAppointmentDetails}
             />

--- a/frontend/src/pages/LogisticsPackagesPage.tsx
+++ b/frontend/src/pages/LogisticsPackagesPage.tsx
@@ -1,0 +1,311 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { isAxiosError } from 'axios';
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { logisticsPackageAPI, driverAPI, collectorAPI, carAPI } from '../services/api';
+import { useToast } from '../hooks/useToast';
+import { ToastContainer } from '../components/ui/Toast';
+import type { LogisticsPackageCreateRequest } from '../types/logistics-package';
+
+type CreateFormValues = {
+  nome: string;
+  descricao: string;
+  driver_id: string;
+  collector_id: string;
+  car_id: string;
+};
+
+export const LogisticsPackagesPage: React.FC = () => {
+  const queryClient = useQueryClient();
+  const { success: showToastSuccess, error: showToastError, toasts, removeToast } = useToast();
+
+  const { register, handleSubmit, reset, formState: { errors, isSubmitting } } = useForm<CreateFormValues>({
+    defaultValues: {
+      nome: '',
+      descricao: '',
+      driver_id: '',
+      collector_id: '',
+      car_id: '',
+    },
+  });
+
+  const { data: packagesData, isLoading: isLoadingPackages } = useQuery({
+    queryKey: ['logisticsPackages'],
+    queryFn: () => logisticsPackageAPI.listPackages(),
+    refetchOnWindowFocus: false,
+  });
+
+  const { data: driversData } = useQuery({
+    queryKey: ['activeDrivers'],
+    queryFn: () => driverAPI.getActiveDrivers(),
+    refetchOnWindowFocus: false,
+  });
+
+  const { data: collectorsData } = useQuery({
+    queryKey: ['activeCollectors'],
+    queryFn: () => collectorAPI.getActiveCollectors(),
+    refetchOnWindowFocus: false,
+  });
+
+  const { data: carsData } = useQuery({
+    queryKey: ['activeCars'],
+    queryFn: () => carAPI.getActiveCars(),
+    refetchOnWindowFocus: false,
+  });
+
+  const packages = packagesData?.data ?? [];
+  const drivers = driversData?.drivers ?? [];
+  const collectors = collectorsData?.collectors ?? [];
+  const cars = carsData?.cars ?? [];
+
+  const invalidatePackages = () => {
+    queryClient.invalidateQueries({ queryKey: ['logisticsPackages'] });
+    queryClient.invalidateQueries({ queryKey: ['activeLogisticsPackages'] });
+  };
+
+  const createMutation = useMutation({
+    mutationFn: (payload: LogisticsPackageCreateRequest) => logisticsPackageAPI.createPackage(payload),
+    onSuccess: (response) => {
+      showToastSuccess(response.message ?? 'Pacote criado com sucesso.');
+      invalidatePackages();
+      reset({ nome: '', descricao: '', driver_id: '', collector_id: '', car_id: '' });
+    },
+    onError: (error) => {
+      const fallback = 'Não foi possível criar o pacote logístico.';
+      if (isAxiosError(error)) {
+        const message = error.response?.data?.detail ?? error.message ?? fallback;
+        showToastError(message);
+      } else {
+        showToastError(fallback);
+      }
+    },
+  });
+
+  const updateStatusMutation = useMutation({
+    mutationFn: ({ id, status }: { id: string; status: 'Ativo' | 'Inativo' }) =>
+      logisticsPackageAPI.updatePackage(id, { status }),
+    onSuccess: (response) => {
+      showToastSuccess(response.message ?? 'Pacote atualizado.');
+      invalidatePackages();
+    },
+    onError: () => {
+      showToastError('Não foi possível atualizar o status do pacote.');
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => logisticsPackageAPI.deletePackage(id),
+    onSuccess: (response) => {
+      showToastSuccess(response.message);
+      invalidatePackages();
+    },
+    onError: () => {
+      showToastError('Não foi possível remover o pacote.');
+    },
+  });
+
+  const onSubmit = handleSubmit(async (values) => {
+    await createMutation.mutateAsync({
+      nome: values.nome.trim(),
+      descricao: values.descricao.trim() || undefined,
+      driver_id: values.driver_id,
+      collector_id: values.collector_id,
+      car_id: values.car_id,
+    });
+  });
+
+  const handleStatusToggle = (id: string, currentStatus: 'Ativo' | 'Inativo') => {
+    const nextStatus = currentStatus === 'Ativo' ? 'Inativo' : 'Ativo';
+    updateStatusMutation.mutate({ id, status: nextStatus });
+  };
+
+  const handleDelete = (id: string) => {
+    if (!window.confirm('Deseja realmente remover este pacote logístico?')) {
+      return;
+    }
+    deleteMutation.mutate(id);
+  };
+
+  return (
+    <div className="space-y-8">
+      <ToastContainer toasts={toasts} onRemove={removeToast} />
+
+      <section className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+        <h1 className="text-2xl font-semibold text-gray-900">Pacotes logísticos</h1>
+        <p className="mt-1 text-sm text-gray-500">
+          Cadastre combinações reutilizáveis de motorista, coletora e carro para agilizar os agendamentos.
+        </p>
+
+        <form className="mt-6 grid grid-cols-1 gap-4 md:grid-cols-2" onSubmit={onSubmit}>
+          <div className="md:col-span-2">
+            <label className="block text-sm font-medium text-gray-700">Nome do pacote *</label>
+            <input
+              type="text"
+              {...register('nome', { required: true })}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+              placeholder="Ex.: Manhã Centro"
+              disabled={isSubmitting || createMutation.isPending}
+            />
+            {errors.nome && (
+              <p className="mt-1 text-sm text-red-600">Informe o nome do pacote.</p>
+            )}
+          </div>
+
+          <div className="md:col-span-2">
+            <label className="block text-sm font-medium text-gray-700">Descrição</label>
+            <textarea
+              rows={2}
+              {...register('descricao')}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+              placeholder="Observações adicionais sobre o uso deste pacote"
+              disabled={isSubmitting || createMutation.isPending}
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Motorista *</label>
+            <select
+              {...register('driver_id', { required: true })}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+              disabled={isSubmitting || createMutation.isPending}
+            >
+              <option value="">Selecione um motorista</option>
+              {drivers.map((driver) => (
+                <option key={driver.id} value={driver.id}>
+                  {driver.nome_completo}
+                </option>
+              ))}
+            </select>
+            {errors.driver_id && (
+              <p className="mt-1 text-sm text-red-600">Escolha um motorista ativo.</p>
+            )}
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Coletora *</label>
+            <select
+              {...register('collector_id', { required: true })}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+              disabled={isSubmitting || createMutation.isPending}
+            >
+              <option value="">Selecione uma coletora</option>
+              {collectors.map((collector) => (
+                <option key={collector.id} value={collector.id}>
+                  {collector.nome_completo}
+                </option>
+              ))}
+            </select>
+            {errors.collector_id && (
+              <p className="mt-1 text-sm text-red-600">Escolha uma coletora ativa.</p>
+            )}
+          </div>
+
+          <div className="md:col-span-2">
+            <label className="block text-sm font-medium text-gray-700">Carro *</label>
+            <select
+              {...register('car_id', { required: true })}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+              disabled={isSubmitting || createMutation.isPending}
+            >
+              <option value="">Selecione um carro</option>
+              {cars.map((car) => (
+                <option key={car.id} value={car.id}>
+                  {car.nome}{car.unidade ? ` • ${car.unidade}` : ''}
+                </option>
+              ))}
+            </select>
+            {errors.car_id && (
+              <p className="mt-1 text-sm text-red-600">Escolha um carro disponível.</p>
+            )}
+          </div>
+
+          <div className="md:col-span-2 flex justify-end">
+            <button
+              type="submit"
+              className="inline-flex items-center rounded-md border border-transparent bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-60"
+              disabled={isSubmitting || createMutation.isPending}
+            >
+              {createMutation.isPending ? 'Salvando...' : 'Criar pacote'}
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <section className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+        <div className="flex items-center justify-between">
+          <h2 className="text-xl font-semibold text-gray-900">Pacotes cadastrados</h2>
+          <span className="text-sm text-gray-500">
+            {packages.length} pacote{packages.length === 1 ? '' : 's'} encontrado{packages.length === 1 ? '' : 's'}
+          </span>
+        </div>
+
+        {isLoadingPackages ? (
+          <p className="mt-6 text-sm text-gray-500">Carregando pacotes...</p>
+        ) : packages.length === 0 ? (
+          <p className="mt-6 text-sm text-gray-500">Nenhum pacote cadastrado até o momento.</p>
+        ) : (
+          <div className="mt-6 overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200 text-sm">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-3 text-left font-semibold text-gray-600">Pacote</th>
+                  <th className="px-4 py-3 text-left font-semibold text-gray-600">Motorista</th>
+                  <th className="px-4 py-3 text-left font-semibold text-gray-600">Coletora</th>
+                  <th className="px-4 py-3 text-left font-semibold text-gray-600">Carro</th>
+                  <th className="px-4 py-3 text-left font-semibold text-gray-600">Status</th>
+                  <th className="px-4 py-3 text-left font-semibold text-gray-600">Ações</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200">
+                {packages.map((pkg) => (
+                  <tr key={pkg.id} className="hover:bg-gray-50">
+                    <td className="px-4 py-3">
+                      <div className="font-medium text-gray-900">{pkg.nome}</div>
+                      {pkg.descricao && (
+                        <div className="text-xs text-gray-500">{pkg.descricao}</div>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 text-gray-700">{pkg.driver_nome}</td>
+                    <td className="px-4 py-3 text-gray-700">{pkg.collector_nome}</td>
+                    <td className="px-4 py-3 text-gray-700">{pkg.car_display_name}</td>
+                    <td className="px-4 py-3">
+                      <span className={`inline-flex items-center rounded-full px-2 py-1 text-xs font-semibold ${
+                        pkg.status === 'Ativo'
+                          ? 'bg-green-50 text-green-700'
+                          : 'bg-gray-100 text-gray-500'
+                      }`}>
+                        {pkg.status}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="flex items-center gap-2">
+                        <button
+                          type="button"
+                          onClick={() => handleStatusToggle(pkg.id, pkg.status)}
+                          className="rounded-md border border-gray-300 px-3 py-1 text-xs font-medium text-gray-700 hover:bg-gray-100"
+                          disabled={updateStatusMutation.isPending}
+                        >
+                          {pkg.status === 'Ativo' ? 'Inativar' : 'Ativar'}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleDelete(pkg.id)}
+                          className="rounded-md border border-red-200 px-3 py-1 text-xs font-medium text-red-600 hover:bg-red-50"
+                          disabled={deleteMutation.isPending}
+                        >
+                          Remover
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+};
+
+export default LogisticsPackagesPage;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -50,6 +50,13 @@ import type {
     TagMutationResponse,
     TagUpdateRequest,
 } from '../types/tag';
+import type {
+    LogisticsPackageCreateRequest,
+    LogisticsPackageDeleteResponse,
+    LogisticsPackageListResponse,
+    LogisticsPackageResponse,
+    LogisticsPackageUpdateRequest,
+} from '../types/logistics-package';
 
 const resolveApiBaseUrl = (): string => {
   if (typeof window !== 'undefined' && window.ENV?.API_URL) {
@@ -420,6 +427,77 @@ export const collectorAPI = {
   // Get collector filter options
   getCollectorFilterOptions: async (): Promise<CollectorFilterOptions> => {
     const response = await api.get<CollectorFilterOptions>('/collectors/filter-options');
+    return response.data;
+  },
+};
+
+export const logisticsPackageAPI = {
+  listPackages: async (status?: string): Promise<LogisticsPackageListResponse> => {
+    const params = new URLSearchParams();
+    if (status) {
+      params.append('status_filter', status);
+    }
+
+    const query = params.toString();
+    const response = await api.get<LogisticsPackageListResponse>(
+      `/logistics-packages${query ? `?${query}` : ''}`,
+      { withCredentials: true }
+    );
+
+    return response.data;
+  },
+
+  listActivePackages: async (): Promise<LogisticsPackageListResponse> => {
+    const response = await api.get<LogisticsPackageListResponse>(
+      '/logistics-packages/active',
+      { withCredentials: true }
+    );
+
+    return response.data;
+  },
+
+  getPackage: async (packageId: string): Promise<LogisticsPackageResponse> => {
+    const response = await api.get<LogisticsPackageResponse>(
+      `/logistics-packages/${packageId}`,
+      { withCredentials: true }
+    );
+
+    return response.data;
+  },
+
+  createPackage: async (
+    payload: LogisticsPackageCreateRequest
+  ): Promise<LogisticsPackageResponse> => {
+    const response = await api.post<LogisticsPackageResponse>(
+      '/logistics-packages',
+      payload,
+      { withCredentials: true }
+    );
+
+    return response.data;
+  },
+
+  updatePackage: async (
+    packageId: string,
+    payload: LogisticsPackageUpdateRequest
+  ): Promise<LogisticsPackageResponse> => {
+    const response = await api.patch<LogisticsPackageResponse>(
+      `/logistics-packages/${packageId}`,
+      payload,
+      { withCredentials: true }
+    );
+
+    return response.data;
+  },
+
+  deletePackage: async (
+    packageId: string
+  ): Promise<LogisticsPackageDeleteResponse> => {
+    const response = await api.delete<LogisticsPackageDeleteResponse>(
+      `/logistics-packages/${packageId}`,
+      { withCredentials: true }
+    );
+
     return response.data;
   },
 };

--- a/frontend/src/types/agenda.ts
+++ b/frontend/src/types/agenda.ts
@@ -1,4 +1,5 @@
 import type { AppointmentViewModel } from './appointment';
+import type { LogisticsPackage } from './logistics-package';
 
 export interface CalendarDay {
   date: Date;
@@ -27,11 +28,14 @@ export interface CalendarViewProps {
   onDateSelect: (date: Date) => void;
   onMonthChange: (date: Date) => void;
   onAppointmentStatusChange?: (id: string, status: string) => void;
-  onAppointmentDriverChange?: (appointmentId: string, driverId: string) => void;
-  onAppointmentCollectorChange?: (appointmentId: string, collectorId: string) => void;
+  onAppointmentLogisticsPackageChange?: (
+    appointmentId: string,
+    logisticsPackageId: string | null,
+  ) => void;
   onAppointmentDelete?: (id: string) => void;
   drivers?: Array<{ id: string; nome_completo: string; cnh?: string; telefone?: string }>;
   collectors?: Array<{ id: string; nome_completo: string; cpf?: string; telefone?: string }>;
+  logisticsPackages?: LogisticsPackage[];
   isLoading?: boolean;
 }
 
@@ -41,11 +45,14 @@ export interface DayModalProps {
   date: Date;
   appointments: AppointmentViewModel[];
   onStatusChange?: (id: string, status: string) => void;
-  onDriverChange?: (appointmentId: string, driverId: string) => void;
-  onCollectorChange?: (appointmentId: string, collectorId: string) => void;
+  onLogisticsPackageChange?: (
+    appointmentId: string,
+    logisticsPackageId: string | null,
+  ) => void;
   onDelete?: (id: string) => void;
   drivers?: Array<{ id: string; nome_completo: string; cnh?: string; telefone?: string }>;
   collectors?: Array<{ id: string; nome_completo: string; cpf?: string; telefone?: string }>;
+  logisticsPackages?: LogisticsPackage[];
 }
 
 export interface CalendarNavigationProps {

--- a/frontend/src/types/appointment.ts
+++ b/frontend/src/types/appointment.ts
@@ -20,6 +20,8 @@ export interface Appointment {
   driver_id?: string;
   collector_id?: string;
   car_id?: string;
+   logistics_package_id?: string;
+   logistics_package_name?: string;
   canal_confirmacao?: string;
   data_confirmacao?: string;
   hora_confirmacao?: string;
@@ -75,6 +77,8 @@ export interface AppointmentCreateRequest {
   observacoes?: string;
   driver_id?: string;
   collector_id?: string;
+  car_id?: string;
+  logistics_package_id?: string;
   numero_convenio?: string;
   nome_convenio?: string;
   carteira_convenio?: string;
@@ -162,6 +166,7 @@ export interface AppointmentUpdateRequest {
   driver_id?: string | null;
   collector_id?: string | null;
   car_id?: string | null;
+  logistics_package_id?: string | null;
   numero_convenio?: string | null;
   nome_convenio?: string | null;
   carteira_convenio?: string | null;

--- a/frontend/src/types/logistics-package.ts
+++ b/frontend/src/types/logistics-package.ts
@@ -1,0 +1,52 @@
+export interface LogisticsPackage {
+  id: string;
+  nome: string;
+  descricao?: string | null;
+  driver_id: string;
+  driver_nome: string;
+  collector_id: string;
+  collector_nome: string;
+  car_id: string;
+  car_nome: string;
+  car_unidade?: string | null;
+  car_display_name: string;
+  status: 'Ativo' | 'Inativo';
+}
+
+export interface LogisticsPackageCreateRequest {
+  nome: string;
+  descricao?: string;
+  driver_id: string;
+  collector_id: string;
+  car_id: string;
+}
+
+export interface LogisticsPackageUpdateRequest {
+  nome?: string;
+  descricao?: string | null;
+  driver_id?: string;
+  collector_id?: string;
+  car_id?: string;
+  status?: 'Ativo' | 'Inativo';
+}
+
+export interface LogisticsPackageListResponse {
+  success: boolean;
+  message?: string;
+  data: LogisticsPackage[];
+  total: number;
+  page: number;
+  per_page: number;
+  pages: number;
+}
+
+export interface LogisticsPackageResponse {
+  success: boolean;
+  message?: string;
+  data: LogisticsPackage;
+}
+
+export interface LogisticsPackageDeleteResponse {
+  success: boolean;
+  message: string;
+}


### PR DESCRIPTION
## Summary
- enable inline logistics package selection across cards, calendar, agenda and table views
- show driver and collector info as read-only outside the detailed modal
- reuse appointment update endpoint to persist logistics package changes quickly

## Testing
- npm run lint *(fails: existing eslint errors in unrelated files such as Car/Collector/Driver pages and dist-tests build outputs)*