### PR TITLE
feat: split appointment views by scope

### DIFF
--- a/backend/src/application/dtos/__init__.py
+++ b/backend/src/application/dtos/__init__.py
@@ -7,6 +7,7 @@ from .appointment_dto import (
     AppointmentFilterDTO,
     AppointmentListResponseDTO,
     AppointmentResponseDTO,
+    AppointmentScope,
     DashboardStatsDTO,
     ExcelUploadResponseDTO,
 )
@@ -23,6 +24,7 @@ __all__ = [
     "AppointmentResponseDTO",
     "AppointmentFilterDTO",
     "AppointmentListResponseDTO",
+    "AppointmentScope",
     "ExcelUploadResponseDTO",
     "DashboardStatsDTO",
     "TagCreateDTO",

--- a/backend/src/application/dtos/appointment_dto.py
+++ b/backend/src/application/dtos/appointment_dto.py
@@ -15,6 +15,7 @@ class AppointmentScope(str, Enum):
 
     CURRENT = "current"
     HISTORY = "history"
+    UNSCHEDULED = "unscheduled"
 
 
 class AppointmentCreateDTO(BaseModel):

--- a/backend/src/application/dtos/appointment_dto.py
+++ b/backend/src/application/dtos/appointment_dto.py
@@ -1,14 +1,20 @@
-"""
-Data Transfer Objects for appointment operations.
-"""
+"""Data Transfer Objects for appointment operations."""
 
 from datetime import datetime
+from enum import Enum
 from typing import Dict, List, Optional
 from uuid import UUID
 
 from pydantic import BaseModel, Field
 
 from src.application.dtos.tag_dto import TagSummaryDTO
+
+
+class AppointmentScope(str, Enum):
+    """Allowed temporal segments for appointment listings."""
+
+    CURRENT = "current"
+    HISTORY = "history"
 
 
 class AppointmentCreateDTO(BaseModel):
@@ -130,6 +136,10 @@ class AppointmentFilterDTO(BaseModel):
     status: Optional[str] = None
     page: int = Field(1, ge=1, description="Página")
     page_size: int = Field(50, ge=1, le=100, description="Itens por página")
+    scope: AppointmentScope = Field(
+        default=AppointmentScope.CURRENT,
+        description="Conjunto temporal (current|history)",
+    )
 
 
 class PaginationDTO(BaseModel):
@@ -165,6 +175,8 @@ class ExcelUploadResponseDTO(BaseModel):
     duplicates_found: int = 0
     errors: List[str] = []
     processing_time: Optional[float] = None
+    past_appointments_blocked: int = 0
+    past_appointments_examples: List[str] = []
 
 
 class FilterOptionsDTO(BaseModel):

--- a/backend/src/application/services/appointment_service.py
+++ b/backend/src/application/services/appointment_service.py
@@ -3,7 +3,7 @@ Service for managing appointments business logic.
 """
 
 from datetime import datetime, timedelta
-from typing import Any, BinaryIO, Dict, List, Optional
+from typing import Any, BinaryIO, Dict, List, Optional, Tuple
 
 from pydantic import ValidationError
 
@@ -11,6 +11,7 @@ from src.application.dtos.appointment_dto import (
     AppointmentCreateDTO,
     AppointmentFullUpdateDTO,
     AppointmentResponseDTO,
+    AppointmentScope,
 )
 from src.application.services.excel_parser_service import ExcelParserService
 from src.domain.entities.appointment import Appointment
@@ -136,6 +137,48 @@ class AppointmentService:
                     if appointment.status == "Agendado":
                         appointment.agendado_por = uploader_name
 
+            # Enforce temporal rules: appointments dated before today are rejected
+            today_cutoff = datetime.utcnow().replace(
+                hour=0, minute=0, second=0, microsecond=0
+            )
+            blocked_by_past_dates = [
+                appointment
+                for appointment in parse_result.appointments
+                if appointment.data_agendamento
+                and appointment.data_agendamento < today_cutoff
+            ]
+
+            if blocked_by_past_dates:
+                formatted_examples = [
+                    f"{apt.nome_paciente} – {apt.data_agendamento.strftime('%d/%m/%Y')}"
+                    for apt in blocked_by_past_dates[:5]
+                ]
+
+                errors = list(parse_result.errors)
+                errors.insert(
+                    0,
+                    (
+                        f"{len(blocked_by_past_dates)} agendamentos com data anterior a hoje "
+                        "foram encontrados na planilha."
+                    ),
+                )
+
+                return {
+                    "success": False,
+                    "message": "Planilha contém agendamentos com data no passado.",
+                    "errors": errors,
+                    "total_rows": parse_result.total_rows,
+                    "valid_rows": max(
+                        parse_result.valid_rows - len(blocked_by_past_dates), 0
+                    ),
+                    "invalid_rows": parse_result.invalid_rows
+                    + len(blocked_by_past_dates),
+                    "imported_appointments": 0,
+                    "duplicates_found": 0,
+                    "past_appointments_blocked": len(blocked_by_past_dates),
+                    "past_appointments_examples": formatted_examples,
+                }
+
             # Handle existing appointments if needed
             if replace_existing:
                 # Get distinct units and brands from import
@@ -197,6 +240,8 @@ class AppointmentService:
                 "duplicates_found": duplicates_found,
                 "errors": parse_result.errors,
                 "filename": filename,
+                "past_appointments_blocked": 0,
+                "past_appointments_examples": [],
             }
 
         except Exception as e:
@@ -220,6 +265,7 @@ class AppointmentService:
         driver_id: Optional[str] = None,
         page: int = 1,
         page_size: int = 50,
+        scope: AppointmentScope = AppointmentScope.CURRENT,
     ) -> Dict:
         """
         Get appointments with filters and pagination.
@@ -242,13 +288,15 @@ class AppointmentService:
 
             # Parse date if provided
             parsed_dates = self._parse_filter_date(data)
+            scope_bounds = self._resolve_scope_bounds(scope)
+            date_bounds = self._merge_scope_with_dates(parsed_dates, scope_bounds)
 
             # Get appointments
             appointments = await self.appointment_repository.find_by_filters(
                 nome_unidade=nome_unidade,
                 nome_marca=nome_marca,
-                data_inicio=parsed_dates[0],
-                data_fim=parsed_dates[1],
+                data_inicio=date_bounds[0],
+                data_fim=date_bounds[1],
                 status=status,
                 driver_id=driver_id,
                 skip=skip,
@@ -257,7 +305,7 @@ class AppointmentService:
 
             # Get total count for pagination
             filters = self._build_pagination_filters(
-                nome_unidade, nome_marca, status, parsed_dates
+                nome_unidade, nome_marca, status, date_bounds
             )
             if driver_id:
                 filters["driver_id"] = driver_id
@@ -1060,12 +1108,47 @@ class AppointmentService:
 
         return start_of_day, end_of_day
 
+    def _resolve_scope_bounds(
+        self,
+        scope: AppointmentScope,
+        reference: Optional[datetime] = None,
+    ) -> Tuple[Optional[datetime], Optional[datetime]]:
+        """Return lower/upper bounds based on the requested scope."""
+
+        current_reference = reference or datetime.utcnow()
+        start_of_today = current_reference.replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
+
+        if scope == AppointmentScope.CURRENT:
+            return start_of_today, None
+        if scope == AppointmentScope.HISTORY:
+            return None, start_of_today
+        return None, None
+
+    def _merge_scope_with_dates(
+        self,
+        parsed_dates: Tuple[Optional[datetime], Optional[datetime]],
+        scope_bounds: Tuple[Optional[datetime], Optional[datetime]],
+    ) -> Tuple[Optional[datetime], Optional[datetime]]:
+        """Combine explicit date filters with scope boundaries."""
+
+        lower_candidates = [parsed_dates[0], scope_bounds[0]]
+        lower_values = [value for value in lower_candidates if value is not None]
+        merged_lower = max(lower_values) if lower_values else None
+
+        upper_candidates = [parsed_dates[1], scope_bounds[1]]
+        upper_values = [value for value in upper_candidates if value is not None]
+        merged_upper = min(upper_values) if upper_values else None
+
+        return merged_lower, merged_upper
+
     def _build_pagination_filters(
         self,
         nome_unidade: Optional[str],
         nome_marca: Optional[str],
         status: Optional[str],
-        parsed_dates: tuple[Optional[datetime], Optional[datetime]],
+        date_bounds: Tuple[Optional[datetime], Optional[datetime]],
     ) -> Dict[str, Any]:
         """Build filters for pagination count."""
         filters: Dict[str, Any] = {}
@@ -1075,13 +1158,13 @@ class AppointmentService:
             filters["nome_marca"] = {"$regex": nome_marca, "$options": "i"}
         if status:
             filters["status"] = status
-        if parsed_dates[0] or parsed_dates[1]:
+        if date_bounds[0] or date_bounds[1]:
             # Use "$lt" for the upper bound to match the repository behavior
             # (start inclusive, end exclusive).
             date_filter: Dict[str, Any] = {}
-            if parsed_dates[0]:
-                date_filter["$gte"] = parsed_dates[0]
-            if parsed_dates[1]:
-                date_filter["$lt"] = parsed_dates[1]
+            if date_bounds[0]:
+                date_filter["$gte"] = date_bounds[0]
+            if date_bounds[1]:
+                date_filter["$lt"] = date_bounds[1]
             filters["data_agendamento"] = date_filter
         return filters

--- a/backend/src/infrastructure/repositories/appointment_repository.py
+++ b/backend/src/infrastructure/repositories/appointment_repository.py
@@ -173,7 +173,11 @@ class AppointmentRepository(AppointmentRepositoryInterface):
         if nome_marca:
             query["nome_marca"] = {"$regex": nome_marca, "$options": "i"}
 
-        if data_inicio or data_fim:
+        # Check for special "unscheduled" marker
+        if data_inicio == "unscheduled" and data_fim == "unscheduled":
+            # Filter for appointments without a date
+            query["data_agendamento"] = None
+        elif data_inicio or data_fim:
             date_filter = {}
             if data_inicio:
                 date_filter["$gte"] = data_inicio

--- a/backend/src/presentation/api/v1/endpoints/appointments.py
+++ b/backend/src/presentation/api/v1/endpoints/appointments.py
@@ -21,6 +21,7 @@ from src.application.dtos.appointment_dto import (
     AppointmentFullUpdateDTO,
     AppointmentListResponseDTO,
     AppointmentResponseDTO,
+    AppointmentScope,
     AppointmentUpdateDTO,
     DashboardStatsDTO,
     ExcelUploadResponseDTO,
@@ -242,6 +243,10 @@ async def get_appointments(
     driver_id: str = Query(None, description="Filtrar por ID do motorista"),
     page: int = Query(1, ge=1, description="Número da página"),
     page_size: int = Query(50, ge=1, le=100, description="Itens por página"),
+    scope: AppointmentScope = Query(
+        AppointmentScope.CURRENT,
+        description="Segmento temporal (current|history)",
+    ),
     service: AppointmentService = Depends(get_appointment_service),
 ) -> AppointmentListResponseDTO:
     """
@@ -269,6 +274,7 @@ async def get_appointments(
             driver_id=driver_id,
             page=page,
             page_size=page_size,
+            scope=scope,
         )
 
         # Convert to response DTOs

--- a/backend/tests/test_appointment_date_filter.py
+++ b/backend/tests/test_appointment_date_filter.py
@@ -1,5 +1,8 @@
 from datetime import datetime, timedelta
 
+from datetime import datetime
+
+from src.application.dtos.appointment_dto import AppointmentScope
 from src.application.services.appointment_service import AppointmentService
 from src.application.services.excel_parser_service import ExcelParserService
 
@@ -34,4 +37,46 @@ def test_parse_filter_date_rejects_invalid_format():
         assert False, "Expected ValueError for invalid format"
     except ValueError as e:
         assert "Formato de data inválido" in str(e)
+
+
+def test_resolve_scope_bounds_current_uses_today_floor():
+    service = _make_service()
+    reference = datetime(2025, 1, 18, 12, 30)
+    lower, upper = service._resolve_scope_bounds(
+        AppointmentScope.CURRENT, reference=reference
+    )
+    assert lower == datetime(2025, 1, 18)
+    assert upper is None
+
+
+def test_resolve_scope_bounds_history_limits_upper_bound():
+    service = _make_service()
+    reference = datetime(2025, 1, 18, 12, 30)
+    lower, upper = service._resolve_scope_bounds(
+        AppointmentScope.HISTORY, reference=reference
+    )
+    assert lower is None
+    assert upper == datetime(2025, 1, 18)
+
+
+def test_merge_scope_with_dates_applies_lower_and_upper_limits():
+    service = _make_service()
+    reference = datetime(2025, 1, 18, 8, 0)
+    parsed_dates = (datetime(2025, 1, 20), datetime(2025, 1, 25))
+    scope_bounds = service._resolve_scope_bounds(
+        AppointmentScope.CURRENT, reference=reference
+    )
+    merged = service._merge_scope_with_dates(parsed_dates, scope_bounds)
+    # Lower bound should become the parsed value (as it is after today)
+    assert merged[0] == datetime(2025, 1, 20)
+    # Upper bound remains untouched
+    assert merged[1] == datetime(2025, 1, 25)
+
+    history_bounds = service._resolve_scope_bounds(
+        AppointmentScope.HISTORY, reference=reference
+    )
+    merged_history = service._merge_scope_with_dates(parsed_dates, history_bounds)
+    # Upper bound should be clamped to the start of the reference day
+    assert merged_history[0] == datetime(2025, 1, 20)
+    assert merged_history[1] == datetime(2025, 1, 18)
 

--- a/docs/feature/active/split-schedule-views.md
+++ b/docs/feature/active/split-schedule-views.md
@@ -1,0 +1,48 @@
+# Estudo Técnico – Separação de Agendamentos (Atual vs Histórico)
+
+## Contexto
+Atualmente todos os agendamentos são exibidos em uma única tela/tabela, o que dificulta a visualização e o gerenciamento. O volume crescente de registros e o fato de ações críticas (cadastro manual, upload de planilhas, alteração de status) ficarem disponíveis para qualquer linha aumentam o risco operacional.
+A proposta é dividir em duas visões distintas:
+- **Visão Atual**: registros de hoje em diante.
+- **Visão Histórica**: registros anteriores a hoje (D-1 para trás).
+
+## Objetivo
+Melhorar a usabilidade e o controle sobre os agendamentos, reduzindo risco de alterações indevidas em registros antigos. A segmentação também simplifica o raciocínio para suporte e facilita analisar métricas por contexto temporal.
+
+## Opção Técnica Escolhida
+**Opção 2 – Query Segmentada no Back-end**
+- Implementar endpoints distintos ou parâmetros de filtro de data para trazer dois conjuntos de dados:
+  - `current` → agendamentos >= hoje.
+  - `history` → agendamentos < hoje.
+- Benefícios:
+  - Evita trazer todos os registros de uma vez, reduzindo payload e processamento no front-end.
+  - Melhora a performance e abre espaço para paginações diferenciadas por contexto.
+  - Facilita controle de regras de negócio em cada visão (p. ex. bloqueios no histórico).
+  - Padroniza o contrato entre front-end e back-end, permitindo que futuras integrações reutilizem o mesmo critério temporal.
+
+## Plano de Implementação
+1. **Back-end**
+   - Criar/ajustar endpoints com parâmetro `scope = [current | history]`.
+   - Adicionar lógica de filtro por data diretamente na query, usando o início do dia UTC como corte.
+   - Incluir validação para combinar filtros de data adicionais (`data_inicio`, `data_fim`) com o `scope`, retornando mensagens claras em casos conflitantes.
+   - Retornar dados já segmentados para o front-end, mantendo paginação e metadados consistentes.
+   - Registrar casos de importação com datas inválidas no log para facilitar troubleshooting.
+
+2. **Front-end**
+   - Criar abas/tabs para separar "Agendamentos Atuais" e "Histórico" utilizando estado compartilhado com o hook de busca.
+   - Ajustar `AppointmentFilter` para enviar o parâmetro `scope` e invalidar o cache de queries ao alternar entre abas.
+   - Exibir botões de ação (adicionar, importar, alterar status) **apenas** na visão atual, mantendo indicadores visuais da restrição na aba histórica.
+   - Desabilitar ações na visão histórica e sinalizar o modo somente leitura nos componentes reutilizados (cards, tabela, agenda e calendário).
+   - Mostrar toast resumindo inconsistências de importação (linhas com datas passadas) e oferecer link para baixar relatório completo caso necessário.
+
+3. **Validação de Importação**
+   - Pré-processar planilha de importação no serviço de domínio, separando linhas com `data_agendamento` anterior ao corte atual.
+   - Caso haja registros no passado → bloquear importação desses itens, exibir toast com resumo e manter o arquivo sem persistência parcial.
+   - Relatar no retorno do serviço o total de linhas rejeitadas por data para auditoria.
+
+4. **Controle de Ações**
+   - Implementar toggle de permissões baseado em data:
+     - Datas >= hoje → habilitar ações.
+     - Datas < hoje → somente leitura.
+   - Replicar a regra no back-end (p. ex. evitar `PATCH` em registros históricos) para garantir consistência mesmo em chamadas diretas à API.
+   - Documentar a política de bloqueio no manual de operações para alinhamento com equipes de atendimento.

--- a/frontend/src/components/AppointmentCalendarView.tsx
+++ b/frontend/src/components/AppointmentCalendarView.tsx
@@ -24,6 +24,7 @@ export const AppointmentCalendarView: React.FC<CalendarViewProps> = ({
   collectors = [],
   logisticsPackages = [],
   isLoading = false,
+  isReadOnly = false,
 }) => {
   const [modalDate, setModalDate] = useState<Date | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -164,6 +165,7 @@ export const AppointmentCalendarView: React.FC<CalendarViewProps> = ({
           drivers={drivers}
           collectors={collectors}
           logisticsPackages={logisticsPackages}
+          isReadOnly={isReadOnly}
         />
       )}
     </div>

--- a/frontend/src/components/AppointmentCard.tsx
+++ b/frontend/src/components/AppointmentCard.tsx
@@ -22,15 +22,16 @@ interface AppointmentCardProps {
   appointment: AppointmentViewModel;
   drivers: ActiveDriver[];
   collectors?: ActiveCollector[];
-  onStatusChange: (id: string, status: string) => void;
+  onStatusChange?: (id: string, status: string) => void;
   logisticsPackages?: LogisticsPackage[];
   onLogisticsPackageChange?: (
     appointmentId: string,
     logisticsPackageId: string | null,
   ) => void;
-  onDelete: (id: string) => void;
+  onDelete?: (id: string) => void;
   compact?: boolean;
   onSelect?: (id: string) => void;
+  isReadOnly?: boolean;
 }
 
 const statusOptions = [
@@ -55,6 +56,7 @@ export const AppointmentCard: React.FC<AppointmentCardProps> = ({
   onDelete,
   compact = false,
   onSelect,
+  isReadOnly = false,
 }) => {
   const getCarInfo = (): string => {
     if (appointment.carro) {
@@ -83,6 +85,10 @@ export const AppointmentCard: React.FC<AppointmentCardProps> = ({
 
   const handleDelete = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
+    if (!onDelete) {
+      return;
+    }
+
     if (window.confirm('Tem certeza que deseja excluir este agendamento?')) {
       onDelete(appointment.id);
     }
@@ -153,11 +159,13 @@ export const AppointmentCard: React.FC<AppointmentCardProps> = ({
         
         <select
           value={appointment.status}
-          onChange={(e) => onStatusChange(appointment.id, e.target.value)}
+          onChange={(e) => onStatusChange?.(appointment.id, e.target.value)}
+          disabled={isReadOnly || !onStatusChange}
           className={`
             ml-3 cursor-pointer transition-all flex-shrink-0
             focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-blue-500
             ${getStatusBadgeClass(appointment.status)}
+            ${isReadOnly || !onStatusChange ? 'opacity-60 cursor-not-allowed' : ''}
           `}
         >
           {statusOptions.map((option) => (
@@ -312,9 +320,9 @@ export const AppointmentCard: React.FC<AppointmentCardProps> = ({
 
       {/* Footer */}
       <div className="mt-4 pt-3 border-t border-gray-100 dark:border-slate-800">
-        {onLogisticsPackageChange && (
-          <div className="flex flex-col gap-2 mb-3 md:flex-row">
-            <div className="flex-1">
+        <div className="flex flex-col gap-2 mb-3 md:flex-row">
+          <div className="flex-1">
+            {onLogisticsPackageChange && !isReadOnly ? (
               <select
                 value={appointment.logistics_package_id || ''}
                 onChange={(event) =>
@@ -324,7 +332,7 @@ export const AppointmentCard: React.FC<AppointmentCardProps> = ({
                   )
                 }
                 className={`
-                  w-full border border-gray-300 dark:border-slate-700 bg-white dark:bg-slate-800 text-gray-700 dark:text-slate-100 rounded px-2 py-1.5 
+                  w-full border border-gray-300 dark:border-slate-700 bg-white dark:bg-slate-800 text-gray-700 dark:text-slate-100 rounded px-2 py-1.5
                   focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-indigo-400 focus:border-blue-500 dark:focus:border-indigo-400
                   ${compact ? 'text-xs' : 'text-sm'}
                 `}
@@ -337,20 +345,26 @@ export const AppointmentCard: React.FC<AppointmentCardProps> = ({
                   </option>
                 ))}
               </select>
-            </div>
+            ) : (
+              <div className={`rounded-md border border-blue-100 bg-blue-50 px-2 py-1 ${compact ? 'text-xs' : 'text-sm'} text-blue-700`}>
+                {appointment.logistics_package_name || 'Sem pacote logístico'}
+              </div>
+            )}
           </div>
-        )}
+        </div>
 
         {/* Actions */}
         <div className="flex justify-end">
-          <button
-            onClick={handleDelete}
-            className="p-1.5 text-red-600 hover:text-red-800 hover:bg-red-50 rounded transition-colors"
-            title="Excluir agendamento"
-            type="button"
-          >
-            <TrashIcon className="w-4 h-4" />
-          </button>
+          {!isReadOnly && onDelete && (
+            <button
+              onClick={handleDelete}
+              className="p-1.5 text-red-600 hover:text-red-800 hover:bg-red-50 rounded transition-colors"
+              title="Excluir agendamento"
+              type="button"
+            >
+              <TrashIcon className="w-4 h-4" />
+            </button>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/components/AppointmentCardList.tsx
+++ b/frontend/src/components/AppointmentCardList.tsx
@@ -12,13 +12,14 @@ interface AppointmentCardListProps {
   collectors?: ActiveCollector[];
   logisticsPackages?: LogisticsPackage[];
   isLoading?: boolean;
-  onStatusChange: (id: string, status: string) => void;
+  onStatusChange?: (id: string, status: string) => void;
   onLogisticsPackageChange?: (
     appointmentId: string,
     logisticsPackageId: string | null,
   ) => void;
-  onDelete: (id: string) => void;
+  onDelete?: (id: string) => void;
   onSelect?: (id: string) => void;
+  isReadOnly?: boolean;
 }
 
 const CardSkeleton: React.FC = () => (
@@ -49,6 +50,7 @@ export const AppointmentCardList: React.FC<AppointmentCardListProps> = ({
   onLogisticsPackageChange,
   onDelete,
   onSelect,
+  isReadOnly = false,
 }) => {
   const { isMobile } = useResponsiveLayout();
 
@@ -98,6 +100,7 @@ export const AppointmentCardList: React.FC<AppointmentCardListProps> = ({
           onDelete={onDelete}
           compact={isMobile}
           onSelect={onSelect}
+          isReadOnly={isReadOnly}
         />
       ))}
     </div>

--- a/frontend/src/components/AppointmentFilters.tsx
+++ b/frontend/src/components/AppointmentFilters.tsx
@@ -54,6 +54,7 @@ export const AppointmentFilters: React.FC<AppointmentFiltersProps> = ({
     onFiltersChange({
       page: 1,
       page_size: filters.page_size || 50,
+      scope: filters.scope,
     });
     setLocalSearch('');
     onSearchChange('');

--- a/frontend/src/components/AppointmentFormModal.tsx
+++ b/frontend/src/components/AppointmentFormModal.tsx
@@ -36,7 +36,23 @@ const formSchema = z.object({
   nome_marca: z.string().trim().min(1, 'Informe a marca/clinica'),
   nome_unidade: z.string().trim().min(1, 'Informe a unidade'),
   nome_paciente: z.string().trim().min(1, 'Informe o nome do paciente'),
-  date: z.string().trim().optional(),
+  date: z
+    .string()
+    .trim()
+    .optional()
+    .refine((value) => {
+      if (!value) return true;
+      
+      // Parse the date string to get year, month, day
+      const [year, month, day] = value.split('-').map(Number);
+      const selected = new Date(year, month - 1, day);
+      selected.setHours(0, 0, 0, 0);
+      
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      
+      return selected >= today;
+    }, 'Data deve ser hoje ou no futuro'),
   time: z
     .string()
     .trim()
@@ -71,6 +87,11 @@ const formSchema = z.object({
 });
 
 type FormValues = z.infer<typeof formSchema>;
+
+const getMinDate = () => {
+  const today = new Date();
+  return today.toISOString().split('T')[0];
+};
 
 export function AppointmentFormModal({
   isOpen,
@@ -190,10 +211,19 @@ export function AppointmentFormModal({
 
     let scheduledAt: string | undefined;
 
-    if (trimmedDate && trimmedTime) {
-      const composed = new Date(`${trimmedDate}T${trimmedTime}:00`);
-      if (!Number.isNaN(composed.getTime())) {
-        scheduledAt = composed.toISOString();
+    if (trimmedDate) {
+      if (trimmedTime) {
+        // Com data e hora: usar ambos
+        const composed = new Date(`${trimmedDate}T${trimmedTime}:00`);
+        if (!Number.isNaN(composed.getTime())) {
+          scheduledAt = composed.toISOString();
+        }
+      } else {
+        // Apenas data: adicionar horário padrão 00:00:00
+        const composed = new Date(`${trimmedDate}T00:00:00`);
+        if (!Number.isNaN(composed.getTime())) {
+          scheduledAt = composed.toISOString();
+        }
       }
     }
 
@@ -320,6 +350,7 @@ export function AppointmentFormModal({
             <input
               type="date"
               {...register('date')}
+              min={getMinDate()}
               className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
               disabled={isSubmitting}
             />

--- a/frontend/src/components/AppointmentTable.tsx
+++ b/frontend/src/components/AppointmentTable.tsx
@@ -28,6 +28,7 @@ interface AppointmentTableProps {
   ) => void;
   onDelete?: (id: string) => void;
   onSelect?: (appointmentId: string) => void;
+  isReadOnly?: boolean;
 }
 
 const statusColors = {
@@ -64,6 +65,7 @@ export const AppointmentTable: React.FC<AppointmentTableProps> = ({
   onLogisticsPackageChange,
   onDelete,
   onSelect,
+  isReadOnly = false,
 }) => {
   const [sorting, setSorting] = React.useState<SortingState>([
     { id: 'data_agendamento', desc: false },
@@ -173,9 +175,11 @@ export const AppointmentTable: React.FC<AppointmentTableProps> = ({
               <select
                 value={status}
                 onChange={(e) => onStatusChange?.(row.original.id, e.target.value)}
+                disabled={isReadOnly || !onStatusChange}
                 className={`
                   w-full rounded-full border bg-white px-3 py-1 text-xs font-semibold shadow-sm transition focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-1
                   ${colorClass}
+                  ${isReadOnly || !onStatusChange ? 'opacity-60 cursor-not-allowed' : ''}
                 `}
               >
                 {statusOptions.map((option) => (
@@ -221,7 +225,7 @@ export const AppointmentTable: React.FC<AppointmentTableProps> = ({
             <div className="space-y-3 text-sm text-gray-600">
               <div className="space-y-1">
                 <span className="text-xs font-medium uppercase tracking-wide text-gray-500">Pacote logístico</span>
-                {onLogisticsPackageChange ? (
+                {onLogisticsPackageChange && !isReadOnly ? (
                   <select
                     value={appointment.logistics_package_id || ''}
                     onChange={(event) =>
@@ -275,22 +279,33 @@ export const AppointmentTable: React.FC<AppointmentTableProps> = ({
         enableSorting: false,
         cell: ({ row }) => (
           <div className="flex space-x-2">
-            <button
-              type="button"
-              onClick={(event) => {
-                event.stopPropagation();
-                onDelete?.(row.original.id);
-              }}
-              className="rounded-full p-1 text-red-600 transition-colors hover:bg-red-50 hover:text-red-700"
-              title="Excluir agendamento"
-            >
-              <TrashIcon className="h-4 w-4" />
-            </button>
+            {!isReadOnly && onDelete && (
+              <button
+                type="button"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onDelete?.(row.original.id);
+                }}
+                className="rounded-full p-1 text-red-600 transition-colors hover:bg-red-50 hover:text-red-700"
+                title="Excluir agendamento"
+              >
+                <TrashIcon className="h-4 w-4" />
+              </button>
+            )}
           </div>
         ),
       },
     ],
-    [collectors, drivers, logisticsPackages, onDelete, onLogisticsPackageChange, onSelect, onStatusChange]
+    [
+      collectors,
+      drivers,
+      isReadOnly,
+      logisticsPackages,
+      onDelete,
+      onLogisticsPackageChange,
+      onSelect,
+      onStatusChange,
+    ]
   );
 
   const table = useReactTable({

--- a/frontend/src/components/CalendarDayModal.tsx
+++ b/frontend/src/components/CalendarDayModal.tsx
@@ -20,6 +20,7 @@ export const CalendarDayModal: React.FC<DayModalProps> = ({
   drivers = [],
   collectors = [],
   logisticsPackages = [],
+  isReadOnly = false,
 }) => {
   const dateString = formatCalendarDate(date, 'EEEE, dd \'de\' MMMM \'de\' yyyy');
   const hasAppointments = appointments.length > 0;
@@ -94,11 +95,14 @@ export const CalendarDayModal: React.FC<DayModalProps> = ({
                           appointment={appointment}
                           drivers={drivers as any[]}
                           collectors={collectors as any[]}
-                          onStatusChange={onStatusChange || (() => {})}
+                          onStatusChange={isReadOnly ? undefined : onStatusChange}
                           logisticsPackages={logisticsPackages}
-                          onLogisticsPackageChange={onLogisticsPackageChange}
-                          onDelete={onDelete || (() => {})}
+                          onLogisticsPackageChange={
+                            isReadOnly ? undefined : onLogisticsPackageChange
+                          }
+                          onDelete={isReadOnly ? undefined : onDelete}
                           compact={true}
+                          isReadOnly={isReadOnly}
                         />
                       ))}
                     </div>

--- a/frontend/src/components/CollectorAgendaView.tsx
+++ b/frontend/src/components/CollectorAgendaView.tsx
@@ -17,14 +17,15 @@ interface CollectorAgendaViewProps {
   drivers: ActiveDriver[];
   selectedDate: Date;
   isLoading: boolean;
-  onAppointmentStatusChange: (id: string, status: string) => void;
+  onAppointmentStatusChange?: (id: string, status: string) => void;
   onAppointmentLogisticsPackageChange?: (
     appointmentId: string,
     logisticsPackageId: string | null,
   ) => void;
-  onAppointmentDelete: (id: string) => void;
+  onAppointmentDelete?: (id: string) => void;
   onDateChange?: (date: Date) => void;
   logisticsPackages?: LogisticsPackage[];
+  isReadOnly?: boolean;
 }
 
 interface CollectorAppointments {
@@ -63,6 +64,7 @@ export const CollectorAgendaView: React.FC<CollectorAgendaViewProps> = ({
   onAppointmentDelete,
   onDateChange,
   logisticsPackages = [],
+  isReadOnly = false,
 }) => {
   const selectedDateStr = useMemo(() => {
     return selectedDate.toISOString().split('T')[0];
@@ -435,6 +437,7 @@ export const CollectorAgendaView: React.FC<CollectorAgendaViewProps> = ({
                   onLogisticsPackageChange={onAppointmentLogisticsPackageChange}
                   onDelete={onAppointmentDelete}
                   compact={true}
+                  isReadOnly={isReadOnly}
                 />
               ))}
             </div>

--- a/frontend/src/components/FileUpload.tsx
+++ b/frontend/src/components/FileUpload.tsx
@@ -97,6 +97,34 @@ export const FileUpload: React.FC<FileUploadProps> = ({
       setUploadProgress(100);
 
       setTimeout(() => {
+        if (!result.success) {
+          stopUploading();
+          setIsModalOpen(false);
+
+          const summarySegments: string[] = [];
+          if (result.message) {
+            summarySegments.push(result.message);
+          }
+          if (result.past_appointments_blocked) {
+            summarySegments.push(
+              `Datas no passado: ${result.past_appointments_blocked}`
+            );
+          }
+          if (result.past_appointments_examples && result.past_appointments_examples.length > 0) {
+            summarySegments.push(
+              `Exemplos: ${result.past_appointments_examples.slice(0, 3).join(' | ')}`
+            );
+          }
+          if (result.errors && result.errors.length > 0) {
+            summarySegments.push(
+              `Detalhes: ${result.errors.slice(0, 3).join(' | ')}`
+            );
+          }
+
+          onUploadError(summarySegments.join(' — ') || 'Planilha contém inconsistências.');
+          return;
+        }
+
         onUploadSuccess(result);
         stopUploading();
         setIsModalOpen(false);

--- a/frontend/src/pages/AppointmentsPage.tsx
+++ b/frontend/src/pages/AppointmentsPage.tsx
@@ -43,7 +43,7 @@ export const AppointmentsPage: React.FC = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const selectedAppointmentId = searchParams.get('itemId');
 
-  const [scope, setScope] = useState<'current' | 'history'>('current');
+  const [scope, setScope] = useState<'current' | 'history' | 'unscheduled'>('current');
   const [filters, setFilters] = useState<AppointmentFilter>({
     page: 1,
     page_size: 50,
@@ -161,9 +161,10 @@ export const AppointmentsPage: React.FC = () => {
   }, [scope, selectedAppointmentId]);
 
   const isHistoryScope = scope === 'history';
+  const isUnscheduledScope = scope === 'unscheduled';
   const canEdit = !isHistoryScope;
 
-  const handleScopeChange = (nextScope: 'current' | 'history') => {
+  const handleScopeChange = (nextScope: 'current' | 'history' | 'unscheduled') => {
     if (nextScope === scope) {
       return;
     }
@@ -352,6 +353,17 @@ export const AppointmentsPage: React.FC = () => {
             >
               Histórico
             </button>
+            <button
+              type="button"
+              onClick={() => handleScopeChange('unscheduled')}
+              className={`px-4 py-2 text-sm font-medium rounded-full transition ${
+                scope === 'unscheduled'
+                  ? 'bg-blue-600 text-white shadow'
+                  : 'text-gray-600 hover:text-gray-900'
+              }`}
+            >
+              Sem Data
+            </button>
           </div>
 
           {isHistoryScope && (
@@ -369,7 +381,9 @@ export const AppointmentsPage: React.FC = () => {
               Gerenciamento de Agendamentos
             </h1>
             <p className="mt-2 text-gray-500">
-              {canEdit
+              {isUnscheduledScope
+                ? 'Agendamentos sem data definida aguardando agendamento.'
+                : canEdit
                 ? 'Faça upload de arquivos Excel e gerencie agendamentos.'
                 : 'Visualize agendamentos concluídos para fins de consulta e auditoria.'}
             </p>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -146,6 +146,7 @@ export const appointmentAPI = {
     if (filters.driver_id) params.append('driver_id', filters.driver_id);
     if (filters.page) params.append('page', filters.page.toString());
     if (filters.page_size) params.append('page_size', filters.page_size.toString());
+    if (filters.scope) params.append('scope', filters.scope);
     
     const response = await api.get<AppointmentListResponse>(
       `/appointments/?${params.toString()}`,

--- a/frontend/src/types/agenda.ts
+++ b/frontend/src/types/agenda.ts
@@ -37,6 +37,7 @@ export interface CalendarViewProps {
   collectors?: Array<{ id: string; nome_completo: string; cpf?: string; telefone?: string }>;
   logisticsPackages?: LogisticsPackage[];
   isLoading?: boolean;
+  isReadOnly?: boolean;
 }
 
 export interface DayModalProps {
@@ -53,6 +54,7 @@ export interface DayModalProps {
   drivers?: Array<{ id: string; nome_completo: string; cnh?: string; telefone?: string }>;
   collectors?: Array<{ id: string; nome_completo: string; cpf?: string; telefone?: string }>;
   logisticsPackages?: LogisticsPackage[];
+  isReadOnly?: boolean;
 }
 
 export interface CalendarNavigationProps {

--- a/frontend/src/types/appointment.ts
+++ b/frontend/src/types/appointment.ts
@@ -93,6 +93,7 @@ export interface AppointmentFilter {
   driver_id?: string;
   page?: number;
   page_size?: number;
+  scope?: 'current' | 'history';
 }
 
 export interface PaginationInfo {
@@ -122,6 +123,8 @@ export interface ExcelUploadResponse {
   duplicates_found: number;
   errors: string[];
   processing_time?: number;
+  past_appointments_blocked?: number;
+  past_appointments_examples?: string[];
 }
 
 export interface FilterOptions {


### PR DESCRIPTION
## Summary
- document the backend query segmentation strategy for current versus historic appointments
- add scope-aware filtering and past-date validation to appointment APIs and Excel imports
- update the appointments UI with current/history tabs, read-only historical view, and import toast feedback

## Testing
- `poetry run pytest` *(fails: missing slowapi, mongomock_motor, jwt dependencies in test environment)*
- `npm run lint` *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d4a5027be483238894ac6a415472c1