### PR TITLE
feat(frontend): implement rbac dashboards and navigation

### DIFF
--- a/docs/feature/active/rbac-navigation-and-dashboards.md
+++ b/docs/feature/active/rbac-navigation-and-dashboards.md
@@ -1,0 +1,39 @@
+# RBAC navigation and dashboards
+
+## Contexto
+- Organização da navegação atual não respeita claramente os papéis de acesso e apresenta um único dashboard genérico.
+- Necessidade de separar visão operacional (colaboradores) da visão estratégica (admin) garantindo consistência de permissões.
+- Exigência de aplicar RBAC tanto na UI (menus/botões) quanto nas rotas para evitar acessos diretos.
+
+## Escopo
+- Reestruturar o layout autenticado com sidebar agrupada, breadcrumbs e foco acessível.
+- Criar guardas de rota baseadas em papéis (COLABORADOR/ADMIN) reutilizáveis na aplicação.
+- Implementar dashboards distintos para operação e administração com KPIs, listas e placeholders de métricas.
+- Atualizar roteamento `/dashboard` para redirecionar automaticamente conforme o papel autenticado.
+- Cobrir cenários críticos com testes unitários de navegação/guards e ajustar infraestrutura de testes.
+
+## Tarefas
+- [x] Criar constantes de papel, utilitários de sessão e HOC `withRole`.
+- [x] Refatorar `App.tsx` para usar layout com rotas aninhadas e guards.
+- [x] Reescrever sidebar com grupos “Operação”, “Cadastros” e “Administração” com colapsáveis.
+- [x] Desenvolver `OperationDashboardPage` e `AdminDashboardPage` com serviços mockados.
+- [x] Implementar página 403 com redirect controlado e breadcrumbs globais.
+- [x] Atualizar script de testes para compilar todos os arquivos `*.test.tsx` e adicionar novos cenários RBAC.
+
+## Decisões
+- Utilizado `withRole` baseado em HOC para manter compatibilidade com componentes existentes, evitando alteração profunda em `PrivateRoute`.
+- Serviços de dashboard retornam mocks determinísticos via `dashboardService`, permitindo troca futura pela API real sem refatorar componentes.
+- Breadcrumbs renderizados a partir do `pathname` para evitar dependência manual por página.
+- Testes escritos com `node:test` e `react-dom/server` aproveitando infraestrutura existente sem adicionar bibliotecas externas.
+
+## Checklist
+- [x] RBAC aplicado na sidebar, rotas e botões críticos.
+- [x] `/dashboard` redireciona dinamicamente conforme papel.
+- [x] Dashboards possuem KPIs mínimos, listas/atalhos e estados vazios.
+- [x] Página 403 acessível com foco e redirect.
+- [x] Testes unitários atualizados e rodando via `npm run test`.
+
+## Risks
+- Serviços de dashboard usam mocks; integração futura precisa alinhar formatos de dados reais.
+- Possível necessidade de ajustes nos filtros/atalhos quando endpoints definitivos estiverem disponíveis.
+- Redirecionamento automático em `/403` depende de `window`, já protegido para SSR, porém deve ser reavaliado em ambientes sem browser.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "node -e \"const fs=require('node:fs');fs.rmSync('dist-tests',{recursive:true,force:true});require('esbuild').buildSync({entryPoints:['src/tests/smoke/appointments.test.tsx'],bundle:true,platform:'node',format:'cjs',outfile:'dist-tests/appointments.test.cjs',logLevel:'error',jsx:'automatic'});\" && node --test dist-tests/appointments.test.cjs"
+    "test": "node ./scripts/build-tests.mjs && node --test dist-tests"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.4",

--- a/frontend/scripts/build-tests.mjs
+++ b/frontend/scripts/build-tests.mjs
@@ -1,0 +1,54 @@
+import { buildSync } from 'esbuild';
+import { mkdirSync, readdirSync, rmSync, statSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const projectRoot = join(__dirname, '..');
+const testsRoot = join(projectRoot, 'src', 'tests');
+const distDir = join(projectRoot, 'dist-tests');
+
+const collectTests = (directory) => {
+  const entries = readdirSync(directory);
+  const files = [];
+
+  for (const entry of entries) {
+    const fullPath = join(directory, entry);
+    const stats = statSync(fullPath);
+
+    if (stats.isDirectory()) {
+      files.push(...collectTests(fullPath));
+    } else if (entry.endsWith('.test.ts') || entry.endsWith('.test.tsx')) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+};
+
+const entryPoints = collectTests(testsRoot);
+
+if (entryPoints.length === 0) {
+  console.warn('Nenhum teste encontrado.');
+  process.exit(0);
+}
+
+rmSync(distDir, { recursive: true, force: true });
+mkdirSync(distDir, { recursive: true });
+
+buildSync({
+  entryPoints,
+  outdir: distDir,
+  bundle: true,
+  platform: 'node',
+  format: 'cjs',
+  logLevel: 'error',
+  jsx: 'automatic',
+  sourcemap: false,
+  outbase: testsRoot,
+  outExtension: { '.js': '.cjs' },
+});
+
+const relativeEntries = entryPoints.map((entry) => relative(testsRoot, entry));
+console.info(`Testes compilados: ${relativeEntries.join(', ')}`);

--- a/frontend/src/components/rbac/withRole.tsx
+++ b/frontend/src/components/rbac/withRole.tsx
@@ -1,0 +1,59 @@
+import type { ComponentType } from 'react';
+import React from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import type { Role } from '../../constants/roles';
+import { ROLES } from '../../constants/roles';
+import { useAuth } from '../../hooks/useAuth';
+import { getUserRole } from '../../utils/session';
+
+interface LoadingFallbackProps {
+  message?: string;
+}
+
+const LoadingFallback: React.FC<LoadingFallbackProps> = ({ message }) => (
+  <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-slate-950">
+    <div className="text-center" role="status" aria-live="polite">
+      <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-blue-600 mx-auto" />
+      <p className="mt-3 text-gray-600 dark:text-slate-300 text-sm font-medium">
+        {message ?? 'Carregando permissões...'}
+      </p>
+    </div>
+  </div>
+);
+
+export function withRole<P extends Record<string, unknown>>(
+  allowedRoles: Role[],
+) {
+  return (WrappedComponent: ComponentType<P>): React.FC<P> => {
+    const RoleGuard: React.FC<P> = (props) => {
+      const { user, isLoading } = useAuth();
+      const location = useLocation();
+
+      if (isLoading) {
+        return <LoadingFallback message="Verificando permissões" />;
+      }
+
+      const role = getUserRole(user);
+
+      if (!allowedRoles.includes(role)) {
+        const fallbackTarget = allowedRoles.includes(ROLES.ADMIN)
+          ? '/dashboard'
+          : '/dashboard';
+
+        return (
+          <Navigate
+            to="/403"
+            state={{ from: location.pathname, fallbackTarget }}
+            replace
+          />
+        );
+      }
+
+      return <WrappedComponent {...(props as P)} />;
+    };
+
+    RoleGuard.displayName = `withRole(${WrappedComponent.displayName ?? WrappedComponent.name ?? 'Component'})`;
+
+    return RoleGuard;
+  };
+}

--- a/frontend/src/components/ui/Breadcrumbs.tsx
+++ b/frontend/src/components/ui/Breadcrumbs.tsx
@@ -1,0 +1,81 @@
+import React, { useMemo } from 'react';
+import { Link, useLocation } from 'react-router-dom';
+
+interface BreadcrumbItem {
+  label: string;
+  path: string;
+  isCurrent: boolean;
+}
+
+const LABEL_MAP: Record<string, { label: string; path?: string }> = {
+  dashboard: { label: 'Dashboard', path: '/dashboard' },
+  operacao: { label: 'Operação', path: '/dashboard/operacao' },
+  admin: { label: 'Administração', path: '/dashboard/admin' },
+  agendamentos: { label: 'Agendamentos', path: '/agendamentos' },
+  cadastros: { label: 'Cadastros' },
+  motoristas: { label: 'Motoristas', path: '/cadastros/motoristas' },
+  coletoras: { label: 'Coletoras', path: '/cadastros/coletoras' },
+  carros: { label: 'Carros', path: '/cadastros/carros' },
+  pacotes: { label: 'Pacotes', path: '/cadastros/pacotes' },
+  usuarios: { label: 'Usuários', path: '/admin/usuarios' },
+  tags: { label: 'Tags', path: '/admin/tags' },
+  adminArea: { label: 'Administração', path: '/admin' },
+};
+
+export const Breadcrumbs: React.FC = () => {
+  const location = useLocation();
+
+  const items = useMemo<BreadcrumbItem[]>(() => {
+    const segments = location.pathname.split('/').filter(Boolean);
+    const breadcrumbs: BreadcrumbItem[] = [
+      {
+        label: 'Início',
+        path: '/dashboard',
+        isCurrent: segments.length === 0,
+      },
+    ];
+
+    let accumulatedPath = '';
+
+    segments.forEach((segment, index) => {
+      accumulatedPath += `/${segment}`;
+      const mapEntry = LABEL_MAP[segment] ?? {
+        label: segment.charAt(0).toUpperCase() + segment.slice(1),
+      };
+
+      const path = mapEntry.path ?? accumulatedPath;
+
+      breadcrumbs.push({
+        label: mapEntry.label,
+        path,
+        isCurrent: index === segments.length - 1,
+      });
+    });
+
+    return breadcrumbs;
+  }, [location.pathname]);
+
+  return (
+    <nav className="flex" aria-label="Breadcrumb">
+      <ol className="inline-flex items-center space-x-1 text-sm text-gray-500 dark:text-slate-400">
+        {items.map((item, index) => (
+          <li key={`${item.path}-${item.label}`} className="inline-flex items-center">
+            {index !== 0 && <span className="mx-2 text-gray-300">/</span>}
+            {item.isCurrent ? (
+              <span className="font-medium text-gray-700 dark:text-slate-100" aria-current="page">
+                {item.label}
+              </span>
+            ) : (
+              <Link
+                to={item.path}
+                className="hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+              >
+                {item.label}
+              </Link>
+            )}
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+};

--- a/frontend/src/constants/roles.ts
+++ b/frontend/src/constants/roles.ts
@@ -1,0 +1,11 @@
+export const ROLES = {
+  ADMIN: 'ADMIN',
+  COLABORADOR: 'COLABORADOR',
+} as const;
+
+export type Role = (typeof ROLES)[keyof typeof ROLES];
+
+export const ROLE_LABELS: Record<Role, string> = {
+  [ROLES.ADMIN]: 'Administrador',
+  [ROLES.COLABORADOR]: 'Colaborador',
+};

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -26,14 +26,23 @@ export function AuthProvider({ children }: AuthProviderProps) {
       return null;
     }
 
-    if (typeof rawUser.is_admin === 'undefined' && rawUser.role) {
-      return {
-        ...rawUser,
-        is_admin: rawUser.role === 'admin',
-      };
-    }
+    const normalizedRole = (() => {
+      if (rawUser.role) {
+        return rawUser.role === 'admin' ? 'admin' : 'colaborador';
+      }
 
-    return rawUser;
+      if (rawUser.is_admin) {
+        return 'admin';
+      }
+
+      return 'colaborador';
+    })();
+
+    return {
+      ...rawUser,
+      is_admin: normalizedRole === 'admin',
+      role: normalizedRole,
+    };
   };
 
   // Initialize authentication state on mount

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -1,0 +1,40 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Outlet, useLocation } from 'react-router-dom';
+import { Navigation } from '../components/Navigation';
+import { Breadcrumbs } from '../components/ui/Breadcrumbs';
+
+export const AppLayout: React.FC = () => {
+  const [isNavigationCollapsed, setIsNavigationCollapsed] = useState(false);
+  const mainContentRef = useRef<HTMLDivElement>(null);
+  const location = useLocation();
+
+  useEffect(() => {
+    if (mainContentRef.current) {
+      mainContentRef.current.focus();
+    }
+  }, [location.pathname]);
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-slate-900 text-slate-900 dark:text-slate-100 flex transition-colors duration-300">
+      <Navigation
+        isCollapsed={isNavigationCollapsed}
+        onToggleCollapse={() =>
+          setIsNavigationCollapsed((previousState) => !previousState)
+        }
+      />
+      <div className="flex-1 flex flex-col">
+        <div className="px-6 py-4 border-b border-gray-200 dark:border-slate-800 bg-white/70 dark:bg-slate-950/60 backdrop-blur">
+          <Breadcrumbs />
+        </div>
+        <div
+          ref={mainContentRef}
+          tabIndex={-1}
+          className="flex-1 px-6 py-6 focus:outline-none"
+          aria-live="polite"
+        >
+          <Outlet />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/pages/Forbidden.tsx
+++ b/frontend/src/pages/Forbidden.tsx
@@ -1,0 +1,80 @@
+import React, { useEffect, useRef } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+const REDIRECT_DELAY = 4000;
+
+interface ForbiddenLocationState {
+  from?: string;
+  fallbackTarget?: string;
+}
+
+export const ForbiddenPage: React.FC = () => {
+  const headingRef = useRef<HTMLHeadingElement>(null);
+  const navigate = useNavigate();
+  const location = useLocation();
+  const state = location.state as ForbiddenLocationState | null;
+  const fallbackTarget = state?.fallbackTarget ?? '/dashboard';
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      headingRef.current?.focus();
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return undefined;
+    }
+
+    const timeout = window.setTimeout(() => {
+      navigate(fallbackTarget, { replace: true });
+    }, REDIRECT_DELAY);
+
+    return () => window.clearTimeout(timeout);
+  }, [fallbackTarget, navigate]);
+
+  return (
+    <div className="flex flex-col items-center justify-center h-full text-center space-y-6">
+      <div className="inline-flex items-center justify-center h-16 w-16 rounded-full bg-red-100 text-red-600">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          className="h-8 w-8"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={1.5}
+            d="M12 9v3m0 3h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L4.34 16c-.77 1.333.192 3 1.732 3z"
+          />
+        </svg>
+      </div>
+      <div role="alert" aria-live="assertive" className="space-y-3 max-w-md">
+        <h1
+          ref={headingRef}
+          tabIndex={-1}
+          className="text-2xl font-semibold text-gray-900 dark:text-slate-100"
+        >
+          Acesso não autorizado
+        </h1>
+        <p className="text-gray-600 dark:text-slate-300">
+          Você não tem permissão para acessar
+          {state?.from ? ` “${state.from}”` : ' este conteúdo'} com o seu papel atual.
+        </p>
+        <p className="text-sm text-gray-500 dark:text-slate-400">
+          Você será redirecionado automaticamente para o seu dashboard padrão em alguns segundos.
+        </p>
+        <button
+          type="button"
+          onClick={() => navigate(fallbackTarget, { replace: true })}
+          className="inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+        >
+          Ir agora para o dashboard
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/pages/dashboard/AdminDashboardPage.tsx
+++ b/frontend/src/pages/dashboard/AdminDashboardPage.tsx
@@ -1,0 +1,309 @@
+import { useQuery } from '@tanstack/react-query';
+import React, { useMemo, useState } from 'react';
+import {
+  ChartBarIcon,
+  ChartPieIcon,
+  ChartLineIcon,
+  ShieldCheckIcon,
+  BellAlertIcon,
+} from '@heroicons/react/24/outline';
+import { dashboardService } from '../../services/dashboard';
+import type { AdminPeriod } from '../../services/dashboard';
+
+const periodLabels: Record<AdminPeriod, string> = {
+  '7d': 'Últimos 7 dias',
+  '30d': 'Últimos 30 dias',
+  '90d': 'Últimos 90 dias',
+};
+
+const percentageFormatter = new Intl.NumberFormat('pt-BR', {
+  style: 'percent',
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 1,
+});
+
+export const AdminDashboardPage: React.FC = () => {
+  const [period, setPeriod] = useState<AdminPeriod>('30d');
+
+  const { data: kpis } = useQuery({
+    queryKey: ['adminKpis', period],
+    queryFn: () => dashboardService.fetchAdminKpis(period),
+    staleTime: 60_000,
+  });
+
+  const { data: trends } = useQuery({
+    queryKey: ['adminTrends', period],
+    queryFn: () => dashboardService.fetchTrends(period),
+    staleTime: 60_000,
+  });
+
+  const { data: topUnits } = useQuery({
+    queryKey: ['adminTopUnits'],
+    queryFn: () => dashboardService.fetchTopUnits(),
+    staleTime: 120_000,
+  });
+
+  const { data: utilization } = useQuery({
+    queryKey: ['adminResourceUtilization'],
+    queryFn: () => dashboardService.fetchResourceUtilization(),
+    staleTime: 120_000,
+  });
+
+  const { data: alerts } = useQuery({
+    queryKey: ['adminAlerts'],
+    queryFn: () => dashboardService.fetchAlerts(),
+    staleTime: 15_000,
+  });
+
+  const chartPoints = useMemo(() => {
+    if (!trends || trends.length === 0) {
+      return '';
+    }
+
+    const maxValue = Math.max(...trends.map((point) => point.value));
+    const minValue = Math.min(...trends.map((point) => point.value));
+    const range = maxValue - minValue || 1;
+
+    return trends
+      .map((point, index) => {
+        const x = (index / (trends.length - 1)) * 100;
+        const y = 100 - ((point.value - minValue) / range) * 100;
+        return `${x},${y}`;
+      })
+      .join(' ');
+  }, [trends]);
+
+  return (
+    <div className="space-y-8">
+      <header className="space-y-2">
+        <p className="text-sm font-semibold uppercase tracking-wide text-purple-600">Dashboard administrativo</p>
+        <h1 className="text-3xl font-bold text-gray-900 dark:text-white">Visão estratégica do negócio</h1>
+        <p className="text-gray-600 dark:text-slate-300 max-w-2xl">
+          Acompanhe tendências, performance operacional e alertas críticos para tomar decisões rápidas e alinhar a operação à
+          estratégia.
+        </p>
+      </header>
+
+      <section aria-labelledby="admin-kpis" className="space-y-4">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <h2 id="admin-kpis" className="text-xl font-semibold text-gray-900 dark:text-white">
+            KPIs principais
+          </h2>
+          <div className="inline-flex items-center rounded-lg border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-1 text-sm shadow-sm" role="radiogroup">
+            {(Object.keys(periodLabels) as AdminPeriod[]).map((value) => (
+              <button
+                key={value}
+                type="button"
+                role="radio"
+                aria-checked={period === value}
+                onClick={() => {
+                  setPeriod(value);
+                  window.dispatchEvent(
+                    new CustomEvent('dashboard:period-changed', {
+                      detail: { period: value },
+                    }),
+                  );
+                }}
+                className={`px-3 py-1.5 rounded-md font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 focus-visible:ring-offset-2 ${
+                  period === value
+                    ? 'bg-purple-600 text-white shadow'
+                    : 'text-gray-600 hover:text-gray-900 dark:text-slate-300 dark:hover:text-white'
+                }`}
+              >
+                {periodLabels[value]}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+          {[{
+            label: 'Total de agendamentos',
+            value: kpis?.totalAppointments ?? 0,
+            icon: ChartBarIcon,
+            accent: 'bg-purple-100 text-purple-600',
+          },
+          {
+            label: 'Taxa de confirmação',
+            value: kpis?.confirmationRate ?? 0,
+            icon: ChartPieIcon,
+            accent: 'bg-emerald-100 text-emerald-600',
+            format: percentageFormatter,
+          },
+          {
+            label: 'No-show',
+            value: kpis?.noShowRate ?? 0,
+            icon: ShieldCheckIcon,
+            accent: 'bg-orange-100 text-orange-600',
+            format: percentageFormatter,
+          },
+          {
+            label: 'Cancelamentos',
+            value: kpis?.cancellationRate ?? 0,
+            icon: BellAlertIcon,
+            accent: 'bg-red-100 text-red-600',
+            format: percentageFormatter,
+          }].map(({ label, value, icon: Icon, accent, format }) => (
+            <article
+              key={label}
+              className="rounded-xl border border-gray-200 dark:border-slate-800 bg-white dark:bg-slate-950 p-5 shadow-sm"
+            >
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm text-gray-500 dark:text-slate-400">{label}</p>
+                  <p className="mt-2 text-3xl font-bold text-gray-900 dark:text-white">
+                    {format ? format.format(value) : value.toLocaleString('pt-BR')}
+                  </p>
+                </div>
+                <span className={`inline-flex h-12 w-12 items-center justify-center rounded-full ${accent}`}>
+                  <Icon className="h-6 w-6" aria-hidden="true" />
+                </span>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section aria-labelledby="trend" className="grid grid-cols-1 gap-6 xl:grid-cols-3">
+        <article className="xl:col-span-2 rounded-xl border border-gray-200 dark:border-slate-800 bg-white dark:bg-slate-950 p-5 shadow-sm">
+          <header className="flex items-center justify-between">
+            <div>
+              <h2 id="trend" className="text-xl font-semibold text-gray-900 dark:text-white">
+                Tendência de agendamentos
+              </h2>
+              <p className="text-sm text-gray-500 dark:text-slate-400">Volume diário no período selecionado</p>
+            </div>
+            <ChartLineIcon className="h-6 w-6 text-purple-500" aria-hidden="true" />
+          </header>
+          <div className="mt-6 h-56">
+            {trends && trends.length > 0 ? (
+              <svg viewBox="0 0 100 100" className="h-full w-full" role="img" aria-label="Gráfico de tendência de agendamentos">
+                <polyline
+                  fill="none"
+                  strokeWidth={3}
+                  stroke="url(#trendGradient)"
+                  points={chartPoints}
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <defs>
+                  <linearGradient id="trendGradient" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stopColor="#7c3aed" stopOpacity="0.9" />
+                    <stop offset="100%" stopColor="#c4b5fd" stopOpacity="0.5" />
+                  </linearGradient>
+                </defs>
+                {trends.map((point, index) => (
+                  <g key={point.label}>
+                    <circle
+                      cx={(index / (trends.length - 1)) * 100}
+                      cy={100 - ((point.value - Math.min(...trends.map((p) => p.value))) /
+                            (Math.max(...trends.map((p) => p.value)) - Math.min(...trends.map((p) => p.value)) || 1)) * 100}
+                      r={1.5}
+                      fill="#7c3aed"
+                    />
+                    <text
+                      x={(index / (trends.length - 1)) * 100}
+                      y={100}
+                      textAnchor="middle"
+                      dy="12"
+                      fontSize="6"
+                      fill="#64748b"
+                    >
+                      {point.label}
+                    </text>
+                  </g>
+                ))}
+              </svg>
+            ) : (
+              <div className="flex h-full items-center justify-center text-sm text-gray-500 dark:text-slate-400">
+                Sem dados suficientes para o período selecionado.
+              </div>
+            )}
+          </div>
+        </article>
+
+        <article className="rounded-xl border border-gray-200 dark:border-slate-800 bg-white dark:bg-slate-950 p-5 shadow-sm space-y-4">
+          <header>
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-white">Top unidades</h2>
+            <p className="text-sm text-gray-500 dark:text-slate-400">Unidades com maior volume de agendamentos</p>
+          </header>
+          <ol className="space-y-3" role="list">
+            {topUnits && topUnits.length > 0 ? (
+              topUnits.map((unit, index) => (
+                <li key={unit.name} className="flex items-center justify-between rounded-lg border border-gray-100 dark:border-slate-800 px-4 py-3">
+                  <div>
+                    <p className="text-sm font-semibold text-gray-900 dark:text-white">{index + 1}. {unit.name}</p>
+                    <p className="text-xs text-gray-500 dark:text-slate-400">{unit.value} agendamentos</p>
+                  </div>
+                  <span className="text-sm font-semibold text-purple-600">{Math.round((unit.value / (topUnits[0]?.value || 1)) * 100)}%</span>
+                </li>
+              ))
+            ) : (
+              <li className="text-sm text-gray-500 dark:text-slate-400">Sem unidades ranqueadas.</li>
+            )}
+          </ol>
+        </article>
+      </section>
+
+      <section aria-labelledby="resources" className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <article className="rounded-xl border border-gray-200 dark:border-slate-800 bg-white dark:bg-slate-950 p-5 shadow-sm space-y-4">
+          <header>
+            <h2 id="resources" className="text-xl font-semibold text-gray-900 dark:text-white">Utilização de recursos</h2>
+            <p className="text-sm text-gray-500 dark:text-slate-400">Proporção de disponibilidade x demanda</p>
+          </header>
+          <ul className="space-y-4" role="list">
+            {utilization && utilization.length > 0 ? (
+              utilization.map((resource) => (
+                <li key={resource.resource} className="space-y-2">
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="font-medium text-gray-800 dark:text-slate-200">{resource.resource}</span>
+                    <span className="text-gray-500 dark:text-slate-400">{percentageFormatter.format(resource.utilization)}</span>
+                  </div>
+                  <div className="h-2 rounded-full bg-gray-100 dark:bg-slate-800">
+                    <div
+                      className="h-2 rounded-full bg-purple-500"
+                      style={{ width: `${Math.min(100, Math.round(resource.utilization * 100))}%` }}
+                      role="presentation"
+                    />
+                  </div>
+                </li>
+              ))
+            ) : (
+              <li className="text-sm text-gray-500 dark:text-slate-400">Sem dados de utilização.</li>
+            )}
+          </ul>
+        </article>
+
+        <article className="rounded-xl border border-gray-200 dark:border-slate-800 bg-white dark:bg-slate-950 p-5 shadow-sm space-y-4">
+          <header className="flex items-center justify-between">
+            <div>
+              <h2 className="text-xl font-semibold text-gray-900 dark:text-white">Alertas</h2>
+              <p className="text-sm text-gray-500 dark:text-slate-400">Itens que exigem atenção da liderança</p>
+            </div>
+            <BellAlertIcon className="h-6 w-6 text-red-500" aria-hidden="true" />
+          </header>
+          <ul className="space-y-3" role="list">
+            {alerts && alerts.length > 0 ? (
+              alerts.map((alert) => (
+                <li
+                  key={alert.id}
+                  className={`rounded-lg border px-4 py-3 text-left ${
+                    alert.severity === 'critical'
+                      ? 'border-red-200 bg-red-50 text-red-700'
+                      : alert.severity === 'warning'
+                        ? 'border-amber-200 bg-amber-50 text-amber-700'
+                        : 'border-blue-200 bg-blue-50 text-blue-700'
+                  }`}
+                >
+                  <p className="text-sm font-semibold">{alert.title}</p>
+                  <p className="text-xs mt-1">{alert.description}</p>
+                </li>
+              ))
+            ) : (
+              <li className="text-sm text-gray-500 dark:text-slate-400">Nenhum alerta registrado.</li>
+            )}
+          </ul>
+        </article>
+      </section>
+    </div>
+  );
+};

--- a/frontend/src/pages/dashboard/DashboardRedirect.tsx
+++ b/frontend/src/pages/dashboard/DashboardRedirect.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import { ROLES, type Role } from '../../constants/roles';
+import { useAuth } from '../../hooks/useAuth';
+import { getUserRole } from '../../utils/session';
+
+export const getDashboardDestination = (role: Role): string =>
+  role === ROLES.ADMIN ? '/dashboard/admin' : '/dashboard/operacao';
+
+export const DashboardRedirect: React.FC = () => {
+  const { user, isLoading } = useAuth();
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center" role="status" aria-live="polite">
+        <div className="text-center">
+          <div className="mx-auto h-10 w-10 animate-spin rounded-full border-b-2 border-blue-600" />
+          <p className="mt-2 text-sm text-gray-600 dark:text-slate-300">Carregando dashboard...</p>
+        </div>
+      </div>
+    );
+  }
+
+  const role = getUserRole(user);
+  const target = getDashboardDestination(role);
+
+  return <Navigate to={target} replace />;
+};

--- a/frontend/src/pages/dashboard/OperationDashboardPage.tsx
+++ b/frontend/src/pages/dashboard/OperationDashboardPage.tsx
@@ -1,0 +1,275 @@
+import { useQuery } from '@tanstack/react-query';
+import React, { useMemo, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import {
+  ArrowUpTrayIcon,
+  CalendarDaysIcon,
+  CheckCircleIcon,
+  ClockIcon,
+  PlusCircleIcon,
+  XCircleIcon,
+} from '@heroicons/react/24/outline';
+import { dashboardService } from '../../services/dashboard';
+import type { OperationalRange } from '../../services/dashboard';
+
+const dateTimeFormatter = new Intl.DateTimeFormat('pt-BR', {
+  day: '2-digit',
+  month: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+});
+
+const rangeLabels: Record<OperationalRange, string> = {
+  today: 'Hoje',
+  tomorrow: 'Amanhã',
+  week: 'Semana',
+};
+
+export const OperationDashboardPage: React.FC = () => {
+  const navigate = useNavigate();
+  const [range, setRange] = useState<OperationalRange>('today');
+
+  const { data: kpis, isLoading: isLoadingKpis } = useQuery({
+    queryKey: ['operationalKpis'],
+    queryFn: () => dashboardService.fetchOperationalKpis(),
+    staleTime: 30_000,
+  });
+
+  const {
+    data: upcomingAppointments,
+    isLoading: isLoadingUpcoming,
+  } = useQuery({
+    queryKey: ['upcomingAppointments', range],
+    queryFn: () => dashboardService.fetchUpcomingAppointments(range),
+    staleTime: 20_000,
+  });
+
+  const quickLinks = useMemo(
+    () => [
+      { label: 'Motoristas', to: '/cadastros/motoristas' },
+      { label: 'Coletoras', to: '/cadastros/coletoras' },
+      { label: 'Carros', to: '/cadastros/carros' },
+      { label: 'Pacotes', to: '/cadastros/pacotes' },
+    ],
+    [],
+  );
+
+  return (
+    <div className="space-y-8">
+      <header className="space-y-2">
+        <p className="text-sm font-semibold uppercase tracking-wide text-blue-600">Dashboard de operação</p>
+        <h1 className="text-3xl font-bold text-gray-900 dark:text-white">Tudo pronto para o dia?</h1>
+        <p className="text-gray-600 dark:text-slate-300 max-w-2xl">
+          Acompanhe os principais indicadores de hoje, confirme os próximos agendamentos e acesse rapidamente os cadastros
+          necessários para manter a operação fluindo.
+        </p>
+      </header>
+
+      <section aria-labelledby="operation-kpis" className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 id="operation-kpis" className="text-xl font-semibold text-gray-900 dark:text-white">
+            KPIs do dia
+          </h2>
+          <span className="text-sm text-gray-500 dark:text-slate-400">
+            Atualizado em tempo real
+          </span>
+        </div>
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+          {[{
+            label: 'Total agendamentos',
+            value: kpis?.total ?? 0,
+            icon: CalendarDaysIcon,
+            accent: 'bg-blue-100 text-blue-600',
+          },
+          {
+            label: 'Confirmados',
+            value: kpis?.confirmed ?? 0,
+            icon: CheckCircleIcon,
+            accent: 'bg-green-100 text-green-600',
+          },
+          {
+            label: 'Pendentes',
+            value: kpis?.pending ?? 0,
+            icon: ClockIcon,
+            accent: 'bg-amber-100 text-amber-600',
+          },
+          {
+            label: 'Cancelados',
+            value: kpis?.cancelled ?? 0,
+            icon: XCircleIcon,
+            accent: 'bg-red-100 text-red-600',
+          }].map(({ label, value, icon: Icon, accent }) => (
+            <article
+              key={label}
+              className="rounded-xl border border-gray-200 dark:border-slate-800 bg-white dark:bg-slate-950 p-5 shadow-sm"
+            >
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm text-gray-500 dark:text-slate-400">{label}</p>
+                  <p className="mt-2 text-3xl font-bold text-gray-900 dark:text-white">
+                    {isLoadingKpis ? '—' : value}
+                  </p>
+                </div>
+                <span className={`inline-flex h-12 w-12 items-center justify-center rounded-full ${accent}`}>
+                  <Icon className="h-6 w-6" aria-hidden="true" />
+                </span>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section aria-labelledby="upcoming-appointments" className="space-y-4">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <h2 id="upcoming-appointments" className="text-xl font-semibold text-gray-900 dark:text-white">
+              Próximos agendamentos
+            </h2>
+            <p className="text-sm text-gray-500 dark:text-slate-400">
+              Filtre rapidamente para priorizar confirmações e remarcações
+            </p>
+          </div>
+          <div className="inline-flex items-center rounded-lg border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-1 text-sm shadow-sm" role="tablist">
+            {(Object.keys(rangeLabels) as OperationalRange[]).map((value) => (
+              <button
+                key={value}
+                type="button"
+                role="tab"
+                aria-selected={range === value}
+                onClick={() => setRange(value)}
+                className={`px-3 py-1.5 rounded-md font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 ${
+                  range === value
+                    ? 'bg-blue-600 text-white shadow'
+                    : 'text-gray-600 hover:text-gray-900 dark:text-slate-300 dark:hover:text-white'
+                }`}
+              >
+                {rangeLabels[value]}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div className="overflow-hidden rounded-xl border border-gray-200 dark:border-slate-800 bg-white dark:bg-slate-950">
+          {isLoadingUpcoming ? (
+            <div className="py-16 text-center text-gray-500 dark:text-slate-400">Carregando agendamentos...</div>
+          ) : upcomingAppointments && upcomingAppointments.length > 0 ? (
+            <ul className="divide-y divide-gray-200 dark:divide-slate-800" role="list">
+              {upcomingAppointments.map((appointment) => (
+                <li key={appointment.id} className="flex flex-wrap items-center gap-4 px-6 py-4">
+                  <div className="flex-1 min-w-[200px]">
+                    <p className="text-sm font-semibold text-gray-900 dark:text-white">
+                      {appointment.patientName}
+                    </p>
+                    <p className="text-xs text-gray-500 dark:text-slate-400">{appointment.location}</p>
+                  </div>
+                  <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-slate-300">
+                    <CalendarDaysIcon className="h-5 w-5 text-blue-500" aria-hidden="true" />
+                    {dateTimeFormatter.format(new Date(appointment.scheduledAt))}
+                  </div>
+                  <span
+                    className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold ${
+                      appointment.status === 'confirmado'
+                        ? 'bg-green-100 text-green-700'
+                        : appointment.status === 'pendente'
+                          ? 'bg-amber-100 text-amber-700'
+                          : 'bg-red-100 text-red-700'
+                    }`}
+                  >
+                    {appointment.status === 'confirmado'
+                      ? 'Confirmado'
+                      : appointment.status === 'pendente'
+                        ? 'Pendente'
+                        : 'Cancelado'}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <div className="py-16 text-center space-y-3">
+              <p className="text-lg font-semibold text-gray-900 dark:text-white">Sem agendamentos neste período</p>
+              <p className="text-sm text-gray-500 dark:text-slate-400">
+                Importe uma planilha ou cadastre um novo agendamento para começar a visualizar a agenda.
+              </p>
+              <div className="flex justify-center gap-3">
+                <button
+                  type="button"
+                  onClick={() => navigate('/agendamentos')}
+                  className="inline-flex items-center rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+                >
+                  <ArrowUpTrayIcon className="mr-2 h-5 w-5" />
+                  Importar planilha
+                </button>
+                <button
+                  type="button"
+                  onClick={() => navigate('/agendamentos')}
+                  className="inline-flex items-center rounded-md border border-blue-600 px-4 py-2 text-sm font-semibold text-blue-600 hover:bg-blue-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+                >
+                  <PlusCircleIcon className="mr-2 h-5 w-5" />
+                  Novo agendamento
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </section>
+
+      <section aria-labelledby="quick-actions" className="space-y-4">
+        <div className="flex flex-col gap-2">
+          <h2 id="quick-actions" className="text-xl font-semibold text-gray-900 dark:text-white">
+            Acesso rápido
+          </h2>
+          <p className="text-sm text-gray-500 dark:text-slate-400">
+            Importe novos agendamentos ou cadastre diretamente na plataforma
+          </p>
+        </div>
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+          <button
+            type="button"
+            onClick={() => navigate('/agendamentos')}
+            className="group rounded-xl border border-dashed border-blue-300 bg-white dark:bg-slate-950 p-5 text-left shadow-sm transition hover:border-blue-400 hover:shadow"
+          >
+            <div className="flex items-center gap-3">
+              <span className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-blue-100 text-blue-600">
+                <ArrowUpTrayIcon className="h-5 w-5" />
+              </span>
+              <div>
+                <p className="font-semibold text-gray-900 dark:text-white">Importar planilha</p>
+                <p className="text-sm text-gray-500 dark:text-slate-400">
+                  Faça upload do Excel de agendamentos e valide conflitos
+                </p>
+              </div>
+            </div>
+          </button>
+          <button
+            type="button"
+            onClick={() => navigate('/agendamentos')}
+            className="group rounded-xl border border-dashed border-emerald-300 bg-white dark:bg-slate-950 p-5 text-left shadow-sm transition hover:border-emerald-400 hover:shadow"
+          >
+            <div className="flex items-center gap-3">
+              <span className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-emerald-100 text-emerald-600">
+                <PlusCircleIcon className="h-5 w-5" />
+              </span>
+              <div>
+                <p className="font-semibold text-gray-900 dark:text-white">Adicionar agendamento</p>
+                <p className="text-sm text-gray-500 dark:text-slate-400">
+                  Registre manualmente um novo compromisso na agenda
+                </p>
+              </div>
+            </div>
+          </button>
+          {quickLinks.map((link) => (
+            <Link
+              key={link.label}
+              to={link.to}
+              className="group rounded-xl border border-gray-200 dark:border-slate-800 bg-white dark:bg-slate-950 p-5 shadow-sm transition hover:border-blue-400 hover:shadow"
+            >
+              <p className="font-semibold text-gray-900 dark:text-white">{link.label}</p>
+              <p className="mt-1 text-sm text-gray-500 dark:text-slate-400">
+                Gerenciar cadastro de {link.label.toLowerCase()}
+              </p>
+            </Link>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+};

--- a/frontend/src/services/dashboard.ts
+++ b/frontend/src/services/dashboard.ts
@@ -1,0 +1,177 @@
+type OperationalRange = 'today' | 'tomorrow' | 'week';
+
+type AdminPeriod = '7d' | '30d' | '90d';
+
+export interface OperationalKpis {
+  total: number;
+  confirmed: number;
+  pending: number;
+  cancelled: number;
+}
+
+export interface UpcomingAppointmentItem {
+  id: string;
+  patientName: string;
+  scheduledAt: string;
+  status: 'confirmado' | 'pendente' | 'cancelado';
+  location: string;
+}
+
+export interface AdminKpis {
+  totalAppointments: number;
+  confirmationRate: number;
+  noShowRate: number;
+  cancellationRate: number;
+}
+
+export interface TrendPoint {
+  label: string;
+  value: number;
+}
+
+export interface TopEntity {
+  name: string;
+  value: number;
+}
+
+export interface ResourceUtilizationItem {
+  resource: string;
+  utilization: number;
+}
+
+export interface DashboardAlertsItem {
+  id: string;
+  title: string;
+  description: string;
+  severity: 'info' | 'warning' | 'critical';
+}
+
+const BASE_ALERTS: DashboardAlertsItem[] = [
+  {
+    id: 'import-1',
+    title: 'Importação pendente',
+    description: 'Arquivo "agenda_b2b.xlsx" está aguardando validação desde ontem.',
+    severity: 'warning',
+  },
+  {
+    id: 'backlog-1',
+    title: 'Backlog de confirmações',
+    description: '12 agendamentos aguardando confirmação manual há mais de 24h.',
+    severity: 'info',
+  },
+];
+
+const MOCK_TOP_UNITS: TopEntity[] = [
+  { name: 'Clínica Central', value: 58 },
+  { name: 'Unidade Jardins', value: 41 },
+  { name: 'Unidade Paulista', value: 36 },
+];
+
+const MOCK_RESOURCE_UTILIZATION: ResourceUtilizationItem[] = [
+  { resource: 'Motoristas', utilization: 0.82 },
+  { resource: 'Coletoras', utilization: 0.76 },
+  { resource: 'Carros', utilization: 0.65 },
+];
+
+const addDays = (date: Date, days: number): Date => {
+  const next = new Date(date);
+  next.setDate(date.getDate() + days);
+  return next;
+};
+
+const formatDate = (date: Date): string =>
+  new Intl.DateTimeFormat('pt-BR', {
+    day: '2-digit',
+    month: '2-digit',
+  }).format(date);
+
+const startOfCurrentDay = () => {
+  const now = new Date();
+  now.setHours(0, 0, 0, 0);
+  return now;
+};
+
+const baseDate = startOfCurrentDay();
+
+const createUpcomingAppointments = (range: OperationalRange): UpcomingAppointmentItem[] => {
+  const appointments: UpcomingAppointmentItem[] = [];
+  const totalItems = range === 'week' ? 6 : 3;
+
+  for (let index = 0; index < totalItems; index += 1) {
+    const baseScheduledDate =
+      range === 'today'
+        ? baseDate
+        : range === 'tomorrow'
+          ? addDays(baseDate, 1)
+          : addDays(baseDate, index);
+
+    const scheduledDate = new Date(baseScheduledDate);
+    const hour = 8 + index * 2;
+    scheduledDate.setHours(hour, index % 2 === 0 ? 0 : 30, 0, 0);
+
+    appointments.push({
+      id: `${range}-${index}`,
+      patientName: `Paciente ${index + 1}`,
+      scheduledAt: scheduledDate.toISOString(),
+      status: index % 3 === 0 ? 'pendente' : index % 4 === 0 ? 'cancelado' : 'confirmado',
+      location: index % 2 === 0 ? 'Clínica Central' : 'Unidade Jardins',
+    });
+  }
+
+  return appointments;
+};
+
+const createTrendData = (period: AdminPeriod): TrendPoint[] => {
+  const points = period === '7d' ? 7 : period === '30d' ? 10 : 12;
+  return Array.from({ length: points })
+    .map((_, index) => {
+      const day = addDays(baseDate, -index);
+      return {
+        label: formatDate(day),
+        value: Math.max(10, 60 - index * 3 + (index % 2 === 0 ? 5 : -4)),
+      };
+    })
+    .reverse();
+};
+
+export const dashboardService = {
+  async fetchOperationalKpis(): Promise<OperationalKpis> {
+    return {
+      total: 42,
+      confirmed: 31,
+      pending: 7,
+      cancelled: 4,
+    };
+  },
+
+  async fetchUpcomingAppointments(range: OperationalRange): Promise<UpcomingAppointmentItem[]> {
+    return createUpcomingAppointments(range);
+  },
+
+  async fetchAdminKpis(period: AdminPeriod): Promise<AdminKpis> {
+    return {
+      totalAppointments: period === '7d' ? 328 : period === '30d' ? 1412 : 3998,
+      confirmationRate: 0.82,
+      noShowRate: 0.06,
+      cancellationRate: 0.12,
+    };
+  },
+
+  async fetchTrends(period: AdminPeriod): Promise<TrendPoint[]> {
+    return createTrendData(period);
+  },
+
+  async fetchTopUnits(): Promise<TopEntity[]> {
+    return MOCK_TOP_UNITS;
+  },
+
+  async fetchResourceUtilization(): Promise<ResourceUtilizationItem[]> {
+    return MOCK_RESOURCE_UTILIZATION;
+  },
+
+  async fetchAlerts(): Promise<DashboardAlertsItem[]> {
+    return BASE_ALERTS;
+  },
+};
+
+export type { OperationalRange, AdminPeriod };

--- a/frontend/src/tests/rbac/dashboard-redirect.test.tsx
+++ b/frontend/src/tests/rbac/dashboard-redirect.test.tsx
@@ -1,0 +1,13 @@
+import '../setup/test-env';
+import { strict as assert } from 'node:assert';
+import test from 'node:test';
+import { ROLES } from '../../constants/roles';
+import { getDashboardDestination } from '../../pages/dashboard/DashboardRedirect';
+
+test('dashboard colaborador redireciona para visão operacional', () => {
+  assert.equal(getDashboardDestination(ROLES.COLABORADOR), '/dashboard/operacao');
+});
+
+test('dashboard admin redireciona para visão administrativa', () => {
+  assert.equal(getDashboardDestination(ROLES.ADMIN), '/dashboard/admin');
+});

--- a/frontend/src/tests/rbac/navigation.test.tsx
+++ b/frontend/src/tests/rbac/navigation.test.tsx
@@ -1,0 +1,63 @@
+import '../setup/test-env';
+import { strict as assert } from 'node:assert';
+import test from 'node:test';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { MemoryRouter } from 'react-router-dom';
+import { Navigation } from '../../components/Navigation';
+import { AuthContext } from '../../contexts/AuthContext';
+import { ThemeProvider } from '../../contexts/ThemeContext';
+import type { AuthContextType, User } from '../../types/auth';
+
+const createAuthContextValue = (overrides: Partial<AuthContextType>): AuthContextType => ({
+  user: null,
+  isLoading: false,
+  isAuthenticated: true,
+  login: async () => {},
+  logout: async () => {},
+  register: async () => {},
+  refreshUser: async () => {},
+  ...overrides,
+});
+
+const renderNavigation = (user: User) =>
+  renderToStaticMarkup(
+    <AuthContext.Provider value={createAuthContextValue({ user })}>
+      <ThemeProvider>
+        <MemoryRouter initialEntries={[user.is_admin ? '/dashboard/admin' : '/dashboard/operacao']}>
+          <Navigation isCollapsed={false} onToggleCollapse={() => {}} />
+        </MemoryRouter>
+      </ThemeProvider>
+    </AuthContext.Provider>,
+  );
+
+test('colaboradores não visualizam seções administrativas na sidebar', () => {
+  const html = renderNavigation({
+    id: '1',
+    email: 'colaborador@example.com',
+    name: 'Colaborador',
+    created_at: new Date().toISOString(),
+    role: 'colaborador',
+    is_admin: false,
+  });
+
+  assert.ok(html.includes('Operação'));
+  assert.ok(html.includes('Cadastros'));
+  assert.ok(!html.includes('Administração'));
+  assert.ok(!html.includes('Usuários'));
+});
+
+test('administradores visualizam menu de administração completo', () => {
+  const html = renderNavigation({
+    id: '2',
+    email: 'admin@example.com',
+    name: 'Admin',
+    created_at: new Date().toISOString(),
+    role: 'admin',
+    is_admin: true,
+  });
+
+  assert.ok(html.includes('Administração'));
+  assert.ok(html.includes('Usuários'));
+  assert.ok(html.includes('Tags'));
+});

--- a/frontend/src/tests/rbac/withRole.test.tsx
+++ b/frontend/src/tests/rbac/withRole.test.tsx
@@ -1,0 +1,25 @@
+import '../setup/test-env';
+import { strict as assert } from 'node:assert';
+import test from 'node:test';
+import { ROLES } from '../../constants/roles';
+import { userHasRole } from '../../utils/session';
+import type { User } from '../../types/auth';
+
+const buildUser = (overrides: Partial<User>): User => ({
+  id: overrides.id ?? 'user',
+  email: overrides.email ?? 'user@example.com',
+  name: overrides.name ?? 'Usuário',
+  created_at: overrides.created_at ?? new Date().toISOString(),
+  role: overrides.role,
+  is_admin: overrides.is_admin,
+});
+
+test('colaborador não possui acesso a rotas exclusivas de admin', () => {
+  const collaborator = buildUser({ role: 'colaborador', is_admin: false });
+  assert.equal(userHasRole(collaborator, [ROLES.ADMIN]), false);
+});
+
+test('admin possui acesso às rotas compartilhadas', () => {
+  const admin = buildUser({ role: 'admin', is_admin: true });
+  assert.equal(userHasRole(admin, [ROLES.COLABORADOR, ROLES.ADMIN]), true);
+});

--- a/frontend/src/tests/setup/test-env.ts
+++ b/frontend/src/tests/setup/test-env.ts
@@ -1,0 +1,53 @@
+const globalAny = globalThis as typeof globalThis & {
+  window?: Record<string, unknown>;
+  document?: Record<string, unknown>;
+  navigator?: Record<string, unknown>;
+};
+
+if (!globalAny.window) {
+  globalAny.window = {};
+}
+
+const windowAny = globalAny.window as Record<string, unknown> & {
+  matchMedia?: (query: string) => MediaQueryList;
+};
+
+windowAny.ENV = windowAny.ENV ?? { API_URL: 'http://localhost:8000' };
+windowAny.confirm = windowAny.confirm ?? (() => true);
+windowAny.alert = windowAny.alert ?? (() => undefined);
+windowAny.localStorage = windowAny.localStorage ?? {
+  getItem: () => null,
+  setItem: () => undefined,
+  removeItem: () => undefined,
+};
+windowAny.location = windowAny.location ?? {
+  href: 'http://localhost/dashboard',
+  assign: () => undefined,
+  replace: () => undefined,
+};
+windowAny.history = windowAny.history ?? {
+  pushState: () => undefined,
+  replaceState: () => undefined,
+};
+
+if (!windowAny.matchMedia) {
+  windowAny.matchMedia = () => ({
+    matches: false,
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+    dispatchEvent: () => false,
+    media: '',
+    onchange: null,
+  }) as unknown as MediaQueryList;
+}
+
+globalAny.document = globalAny.document ?? {
+  documentElement: {
+    classList: {
+      add: () => undefined,
+      remove: () => undefined,
+    },
+  },
+};
+
+globalAny.navigator = globalAny.navigator ?? { userAgent: 'node' };

--- a/frontend/src/tests/smoke/appointments.test.tsx
+++ b/frontend/src/tests/smoke/appointments.test.tsx
@@ -1,3 +1,4 @@
+import '../setup/test-env';
 import assert from 'node:assert/strict';
 import { randomUUID } from 'node:crypto';
 import { describe, test } from 'node:test';
@@ -80,6 +81,7 @@ describe('Appointments smoke tests', () => {
         collectors={[]}
         tags={[]}
         maxTags={5}
+        logisticsPackages={[]}
       />
     );
 

--- a/frontend/src/utils/session.ts
+++ b/frontend/src/utils/session.ts
@@ -1,0 +1,29 @@
+import type { Role } from '../constants/roles';
+import { ROLES } from '../constants/roles';
+import type { User } from '../types/auth';
+
+const ADMIN_ALIASES = new Set(['admin', 'ADMIN', 'Administrador']);
+
+export const getUserRole = (user?: User | null): Role => {
+  if (!user) {
+    return ROLES.COLABORADOR;
+  }
+
+  if (user.role && ADMIN_ALIASES.has(user.role)) {
+    return ROLES.ADMIN;
+  }
+
+  if (user.is_admin) {
+    return ROLES.ADMIN;
+  }
+
+  return ROLES.COLABORADOR;
+};
+
+export const userHasRole = (user: User | null, allowedRoles: Role[]): boolean => {
+  const role = getUserRole(user);
+  return allowedRoles.includes(role);
+};
+
+export const formatRoleLabel = (role: Role): string =>
+  role === ROLES.ADMIN ? 'Administrador' : 'Colaborador';


### PR DESCRIPTION
## Summary
- reorganize the authenticated layout with a collapsible, role-aware sidebar, breadcrumbs, and a forbidden access page
- add collaborator and admin dashboard pages backed by a mock dashboard service and role-based redirect helpers
- introduce reusable RBAC utilities, update route definitions, expand frontend tests, and document the feature scope

## Testing
- npm run test
- npm run lint *(fails because of pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d58c297d108323b5897fb58ff89a51