### PR TITLE
fix(auth): cap password length at bcrypt limit

### DIFF
--- a/backend/src/application/dtos/user_dto.py
+++ b/backend/src/application/dtos/user_dto.py
@@ -17,7 +17,12 @@ class UserCreateRequest(BaseModel):
     name: str = Field(
         ..., min_length=2, max_length=100, description="User full name"
     )
-    password: str = Field(..., min_length=8, description="User password")
+    password: str = Field(
+        ...,
+        min_length=8,
+        max_length=72,
+        description="User password (minimum 8, maximum 72 characters)",
+    )
     is_admin: bool = Field(
         False, description="Whether user has admin privileges"
     )
@@ -48,7 +53,11 @@ class LoginRequest(BaseModel):
     """DTO for user login request."""
 
     email: str = Field(..., description="User email address")
-    password: str = Field(..., description="User password")
+    password: str = Field(
+        ...,
+        max_length=72,
+        description="User password (maximum 72 characters)",
+    )
 
     @field_validator("email", mode="before")
     @classmethod

--- a/backend/src/application/services/auth_service.py
+++ b/backend/src/application/services/auth_service.py
@@ -574,6 +574,12 @@ class AuthService:
         Returns:
             Hashed password
         """
+        # Bcrypt has a 72-byte limit. Encode to bytes and truncate if necessary
+        password_bytes = password.encode('utf-8')
+        if len(password_bytes) > 72:
+            password_bytes = password_bytes[:72]
+            password = password_bytes.decode('utf-8', errors='ignore')
+        
         return pwd_context.hash(password)
 
     def verify_password(
@@ -589,6 +595,12 @@ class AuthService:
         Returns:
             True if password matches, False otherwise
         """
+        # Bcrypt has a 72-byte limit. Encode to bytes and truncate if necessary
+        password_bytes = plain_password.encode('utf-8')
+        if len(password_bytes) > 72:
+            password_bytes = password_bytes[:72]
+            plain_password = password_bytes.decode('utf-8', errors='ignore')
+        
         return pwd_context.verify(plain_password, hashed_password)
 
     def _is_email_in_admin_whitelist(self, email: str) -> bool:

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from pydantic import ValidationError
 
 from src.application.dtos.user_dto import LoginRequest, UserCreateRequest
 from src.application.services.auth_service import AuthService
@@ -256,6 +257,20 @@ class TestAuthService:
 
         assert auth_service.verify_password(password, hashed) is True
         assert auth_service.verify_password(wrong_password, hashed) is False
+
+    def test_login_request_rejects_password_above_bcrypt_limit(self):
+        """Login DTO should enforce bcrypt 72 character limit."""
+        with pytest.raises(ValidationError):
+            LoginRequest(email="test@example.com", password="x" * 73)
+
+    def test_user_create_rejects_password_above_bcrypt_limit(self):
+        """User creation DTO should enforce bcrypt 72 character limit."""
+        with pytest.raises(ValidationError):
+            UserCreateRequest(
+                email="test@example.com",
+                name="Tester",
+                password="x" * 73,
+            )
 
     @pytest.mark.asyncio
     async def test_get_current_user_valid_token(


### PR DESCRIPTION
## Summary
- enforce bcrypt\'s 72 character limit on LoginRequest and UserCreateRequest
- document the restriction in DTO field descriptions
- add validation tests guarding against passwords longer than the limit

## Testing
- not run (coverage gate prevents partial suite locally)