### PR TITLE
Add patient document management via Cloudflare R2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,16 @@ ME_CONFIG_BASICAUTH_PASSWORD=changeme
 BACKEND_PORT=8000
 BACKEND_SECRET_KEY=your-secret-key-here-change-in-production
 
+# Patient documents storage (Cloudflare R2 / S3 compatible)
+R2_ACCOUNT_ID=
+R2_ACCESS_KEY_ID=
+R2_SECRET_ACCESS_KEY=
+R2_BUCKET_PATIENT_DOCS=
+R2_PRESIGN_TTL_SECONDS=600
+MAX_UPLOAD_MB=10
+ALLOWED_MIME_LIST=application/pdf,image/jpeg,image/png,image/webp,image/heic
+S3_ENDPOINT=
+
 # Frontend
 FRONTEND_PORT=3000
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -34,6 +34,9 @@ python-dateutil==2.8.2
 pytz==2023.3
 httpx==0.26.0
 
+# Storage
+boto3>=1.34.0
+
 # AI/ML Services
 openai>=1.0.0
 

--- a/backend/src/application/common/__init__.py
+++ b/backend/src/application/common/__init__.py
@@ -1,0 +1,5 @@
+"""Shared application layer helpers."""
+
+from .context import RequestContext, UserRole
+
+__all__ = ["RequestContext", "UserRole"]

--- a/backend/src/application/common/context.py
+++ b/backend/src/application/common/context.py
@@ -1,0 +1,29 @@
+"""Request context helpers shared across services."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class UserRole(str, Enum):
+    """Simple role definitions supported by the platform."""
+
+    ADMIN = "admin"
+    COLLABORATOR = "collaborator"
+
+
+class RequestContext(BaseModel):
+    """Information extracted from the incoming request for auditing."""
+
+    user_id: str = Field(..., description="Identificador do usuário autenticado")
+    tenant_id: str = Field(..., description="Tenant associado à requisição")
+    role: UserRole = Field(
+        default=UserRole.COLLABORATOR,
+        description="Perfil de acesso do usuário",
+    )
+    source_ip: Optional[str] = Field(
+        None, description="Endereço IP de origem utilizado para auditoria"
+    )

--- a/backend/src/application/dtos/__init__.py
+++ b/backend/src/application/dtos/__init__.py
@@ -10,6 +10,14 @@ from .appointment_dto import (
     DashboardStatsDTO,
     ExcelUploadResponseDTO,
 )
+from .patient_document_dto import (
+    ConfirmUploadRequestDTO,
+    DownloadUrlResponseDTO,
+    PatientDocumentDTO,
+    PatientDocumentListResponseDTO,
+    PresignUploadRequestDTO,
+    PresignUploadResponseDTO,
+)
 
 __all__ = [
     "AppointmentCreateDTO",
@@ -18,4 +26,10 @@ __all__ = [
     "AppointmentListResponseDTO",
     "ExcelUploadResponseDTO",
     "DashboardStatsDTO",
+    "ConfirmUploadRequestDTO",
+    "DownloadUrlResponseDTO",
+    "PatientDocumentDTO",
+    "PatientDocumentListResponseDTO",
+    "PresignUploadRequestDTO",
+    "PresignUploadResponseDTO",
 ]

--- a/backend/src/application/dtos/patient_document_dto.py
+++ b/backend/src/application/dtos/patient_document_dto.py
@@ -1,0 +1,91 @@
+"""DTOs for patient document operations."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+from src.domain.entities.patient_document import DocumentStatus
+
+
+class PresignUploadRequestDTO(BaseModel):
+    """Input payload required to request a presigned upload URL."""
+
+    patient_id: str = Field(..., description="Identificador do paciente")
+    file_name: str = Field(..., description="Nome original do arquivo")
+    content_type: str = Field(..., description="MIME type do arquivo")
+    file_size: int = Field(..., gt=0, description="Tamanho do arquivo em bytes")
+
+
+class PresignUploadResponseDTO(BaseModel):
+    """Returned data for performing the direct upload."""
+
+    document_id: str = Field(..., description="Identificador do documento")
+    upload_url: str = Field(..., description="URL pré-assinada para upload")
+    headers: Dict[str, str] = Field(
+        default_factory=dict,
+        description="Cabeçalhos adicionais necessários no upload",
+    )
+    expires_in: int = Field(..., description="Tempo de expiração do link em segundos")
+    storage_key: str = Field(..., description="Chave do objeto no bucket")
+
+
+class ConfirmUploadRequestDTO(BaseModel):
+    """Payload utilizado para confirmar um upload concluído."""
+
+    file_size: int = Field(..., gt=0, description="Tamanho final do arquivo em bytes")
+    etag: Optional[str] = Field(
+        None, description="ETag retornado pelo storage (quando disponível)"
+    )
+
+
+class PatientDocumentDTO(BaseModel):
+    """Metadata exposta via API para documentos de paciente."""
+
+    id: str = Field(..., description="Identificador do documento")
+    appointment_id: str = Field(..., description="ID do agendamento")
+    patient_id: str = Field(..., description="Identificador do paciente")
+    original_file_name: str = Field(
+        ..., description="Nome original do arquivo enviado"
+    )
+    sanitized_file_name: str = Field(
+        ..., description="Nome sanitizado do arquivo"
+    )
+    content_type: str = Field(..., description="MIME type do arquivo")
+    file_size: int = Field(..., description="Tamanho do arquivo em bytes")
+    status: DocumentStatus = Field(..., description="Status atual do documento")
+    storage_key: str = Field(..., description="Chave do objeto no bucket")
+    uploader_user_id: Optional[str] = Field(
+        None, description="Usuário que realizou o upload"
+    )
+    source_ip: Optional[str] = Field(
+        None, description="IP de origem registrado no upload"
+    )
+    created_at: datetime = Field(..., description="Data de criação do registro")
+    uploaded_at: Optional[datetime] = Field(
+        None, description="Data de confirmação do upload"
+    )
+    deleted_at: Optional[datetime] = Field(
+        None, description="Data da exclusão lógica"
+    )
+    deleted_by: Optional[str] = Field(
+        None, description="Usuário responsável pela exclusão"
+    )
+    etag: Optional[str] = Field(None, description="ETag informado pelo storage")
+
+
+class PatientDocumentListResponseDTO(BaseModel):
+    """Wrapper para resposta de listagem de documentos."""
+
+    documents: List[PatientDocumentDTO] = Field(
+        default_factory=list, description="Lista de documentos"
+    )
+
+
+class DownloadUrlResponseDTO(BaseModel):
+    """Resposta contendo uma URL temporária de download."""
+
+    url: str = Field(..., description="URL pré-assinada para download")
+    expires_in: int = Field(..., description="Tempo de expiração em segundos")

--- a/backend/src/application/services/__init__.py
+++ b/backend/src/application/services/__init__.py
@@ -4,5 +4,10 @@ Application services.
 
 from .appointment_service import AppointmentService
 from .excel_parser_service import ExcelParserService
+from .patient_document_service import PatientDocumentService
 
-__all__ = ["ExcelParserService", "AppointmentService"]
+__all__ = [
+    "ExcelParserService",
+    "AppointmentService",
+    "PatientDocumentService",
+]

--- a/backend/src/application/services/patient_document_service.py
+++ b/backend/src/application/services/patient_document_service.py
@@ -1,0 +1,292 @@
+"""Service layer for handling patient document lifecycle."""
+
+from __future__ import annotations
+
+import os
+import unicodedata
+from datetime import datetime
+from pathlib import Path
+from uuid import uuid4
+
+from src.application.common import RequestContext, UserRole
+from src.application.dtos.patient_document_dto import (
+    ConfirmUploadRequestDTO,
+    DownloadUrlResponseDTO,
+    PatientDocumentDTO,
+    PatientDocumentListResponseDTO,
+    PresignUploadRequestDTO,
+    PresignUploadResponseDTO,
+)
+from src.domain.base import DomainValidationException, EntityNotFoundException
+from src.domain.entities.patient_document import DocumentStatus, PatientDocument
+from src.domain.repositories.patient_document_repository_interface import (
+    PatientDocumentRepositoryInterface,
+)
+from src.infrastructure.config import Settings
+from src.infrastructure.storage.r2_client import R2StorageClient
+
+
+class PatientDocumentService:
+    """Coordinate operations between API, storage and persistence."""
+
+    def __init__(
+        self,
+        repository: PatientDocumentRepositoryInterface,
+        storage_client: R2StorageClient,
+        settings: Settings,
+    ) -> None:
+        self._repository = repository
+        self._storage = storage_client
+        self._settings = settings
+
+    async def create_presigned_upload(
+        self,
+        *,
+        appointment_id: str,
+        payload: PresignUploadRequestDTO,
+        context: RequestContext,
+    ) -> PresignUploadResponseDTO:
+        """Validate input, persist metadata and return upload instructions."""
+
+        self._ensure_storage_requirements()
+        self._validate_file_constraints(payload)
+
+        sanitized_filename = self._sanitize_filename(payload.file_name)
+        safe_patient_id = self._slugify(payload.patient_id)
+        storage_key = self._build_storage_key(
+            patient_id=safe_patient_id,
+            appointment_id=appointment_id,
+            filename=sanitized_filename,
+        )
+
+        document = PatientDocument(
+            id=uuid4(),
+            appointment_id=appointment_id,
+            tenant_id=context.tenant_id,
+            patient_id=payload.patient_id,
+            original_file_name=payload.file_name,
+            sanitized_file_name=sanitized_filename,
+            content_type=payload.content_type,
+            file_size=payload.file_size,
+            storage_key=storage_key,
+            bucket=self._storage.bucket,
+            uploader_user_id=context.user_id,
+            source_ip=context.source_ip,
+        )
+
+        await self._repository.create(document)
+
+        presign = self._storage.generate_presigned_put(
+            key=storage_key,
+            content_type=payload.content_type,
+        )
+
+        return PresignUploadResponseDTO(
+            document_id=str(document.id),
+            upload_url=presign["url"],
+            headers=presign.get("headers", {}),
+            expires_in=self._settings.r2_presign_ttl_seconds,
+            storage_key=storage_key,
+        )
+
+    async def confirm_upload(
+        self,
+        *,
+        appointment_id: str,
+        document_id: str,
+        payload: ConfirmUploadRequestDTO,
+        context: RequestContext,
+    ) -> PatientDocumentDTO:
+        """Mark a document as uploaded after a successful PUT to R2."""
+
+        document = await self._get_document_or_404(document_id, context.tenant_id)
+        self._ensure_same_appointment(document, appointment_id)
+
+        if document.status not in {DocumentStatus.PENDING, DocumentStatus.AVAILABLE}:
+            raise DomainValidationException(
+                "Documento não pode ser confirmado no estado atual",
+                field="status",
+            )
+
+        if payload.file_size > self._settings.patient_docs_max_upload_bytes:
+            raise DomainValidationException(
+                "Tamanho do arquivo excede o limite configurado",
+                field="file_size",
+            )
+
+        document.file_size = payload.file_size
+        document.mark_uploaded(uploaded_at=datetime.utcnow(), etag=payload.etag)
+        updated = await self._repository.update(document)
+        return self._to_dto(updated)
+
+    async def list_documents(
+        self, *, appointment_id: str, context: RequestContext
+    ) -> PatientDocumentListResponseDTO:
+        """Return all non-deleted documents for the appointment."""
+
+        documents = await self._repository.list_by_appointment(
+            appointment_id=appointment_id,
+            tenant_id=context.tenant_id,
+            include_deleted=False,
+        )
+        return PatientDocumentListResponseDTO(
+            documents=[self._to_dto(doc) for doc in documents]
+        )
+
+    async def create_download_url(
+        self,
+        *,
+        appointment_id: str,
+        document_id: str,
+        context: RequestContext,
+    ) -> DownloadUrlResponseDTO:
+        """Generate a presigned GET URL for the requested document."""
+
+        document = await self._get_document_or_404(document_id, context.tenant_id)
+        self._ensure_same_appointment(document, appointment_id)
+
+        if document.status != DocumentStatus.AVAILABLE:
+            raise DomainValidationException(
+                "Documento não está disponível para download",
+                field="status",
+            )
+
+        url = self._storage.generate_presigned_get(key=document.storage_key)
+        return DownloadUrlResponseDTO(
+            url=url, expires_in=self._settings.r2_presign_ttl_seconds
+        )
+
+    async def delete_document(
+        self,
+        *,
+        appointment_id: str,
+        document_id: str,
+        hard_delete: bool,
+        context: RequestContext,
+    ) -> PatientDocumentDTO:
+        """Soft delete (default) or hard delete a document."""
+
+        document = await self._get_document_or_404(document_id, context.tenant_id)
+        self._ensure_same_appointment(document, appointment_id)
+
+        if document.status == DocumentStatus.HARD_DELETED:
+            raise DomainValidationException(
+                "Documento já foi removido permanentemente",
+                field="status",
+            )
+
+        now = datetime.utcnow()
+
+        if hard_delete:
+            if context.role != UserRole.ADMIN:
+                raise DomainValidationException(
+                    "Somente administradores podem realizar exclusão definitiva",
+                    field="role",
+                )
+
+            await self._storage.delete_object(key=document.storage_key)
+            document.mark_hard_deleted(deleted_at=now, user_id=context.user_id)
+        else:
+            if document.status == DocumentStatus.SOFT_DELETED:
+                raise DomainValidationException(
+                    "Documento já está excluído",
+                    field="status",
+                )
+            document.mark_soft_deleted(deleted_at=now, user_id=context.user_id)
+
+        updated = await self._repository.update(document)
+        return self._to_dto(updated)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _ensure_storage_requirements(self) -> None:
+        if not self._settings.r2_access_key_id or not self._settings.r2_secret_access_key:
+            raise DomainValidationException(
+                "Credenciais do R2 não configuradas corretamente",
+                field="R2_ACCESS_KEY_ID",
+            )
+        if not self._settings.r2_bucket_patient_docs:
+            raise DomainValidationException(
+                "Bucket de documentos não configurado",
+                field="R2_BUCKET_PATIENT_DOCS",
+            )
+
+    def _validate_file_constraints(self, payload: PresignUploadRequestDTO) -> None:
+        if (
+            payload.content_type
+            not in self._settings.allowed_patient_document_mime_types
+        ):
+            raise DomainValidationException(
+                "Tipo de arquivo não permitido",
+                field="content_type",
+            )
+
+        if payload.file_size > self._settings.patient_docs_max_upload_bytes:
+            raise DomainValidationException(
+                "Tamanho do arquivo excede o limite configurado",
+                field="file_size",
+            )
+
+    async def _get_document_or_404(
+        self, document_id: str, tenant_id: str
+    ) -> PatientDocument:
+        document = await self._repository.find_by_id(document_id, tenant_id)
+        if not document:
+            raise EntityNotFoundException("PatientDocument", document_id)
+        return document
+
+    @staticmethod
+    def _ensure_same_appointment(
+        document: PatientDocument, appointment_id: str
+    ) -> None:
+        if document.appointment_id != appointment_id:
+            raise DomainValidationException(
+                "Documento não pertence ao agendamento informado",
+                field="appointment_id",
+            )
+
+    def _to_dto(self, document: PatientDocument) -> PatientDocumentDTO:
+        return PatientDocumentDTO(
+            id=str(document.id),
+            appointment_id=document.appointment_id,
+            patient_id=document.patient_id,
+            original_file_name=document.original_file_name,
+            sanitized_file_name=document.sanitized_file_name,
+            content_type=document.content_type,
+            file_size=document.file_size,
+            status=document.status,
+            storage_key=document.storage_key,
+            uploader_user_id=document.uploader_user_id,
+            source_ip=document.source_ip,
+            created_at=document.created_at,
+            uploaded_at=document.uploaded_at,
+            deleted_at=document.deleted_at,
+            deleted_by=document.deleted_by,
+            etag=document.etag,
+        )
+
+    def _build_storage_key(
+        self, *, patient_id: str, appointment_id: str, filename: str
+    ) -> str:
+        now = datetime.utcnow()
+        return (
+            f"patients/{patient_id}/appointments/{appointment_id}/"
+            f"{now.year:04d}/{now.month:02d}/{uuid4()}_{filename}"
+        )
+
+    def _sanitize_filename(self, filename: str) -> str:
+        name = Path(filename).name
+        stem, ext = os.path.splitext(name)
+        sanitized_stem = self._slugify(stem) or "documento"
+        sanitized_ext = ext.lower()
+        return f"{sanitized_stem}{sanitized_ext}"
+
+    def _slugify(self, value: str) -> str:
+        normalized = unicodedata.normalize("NFKD", value)
+        ascii_value = normalized.encode("ascii", "ignore").decode("ascii")
+        allowed = [c if c.isalnum() else "-" for c in ascii_value]
+        slug = "".join(allowed)
+        while "--" in slug:
+            slug = slug.replace("--", "-")
+        return slug.strip("-").lower()

--- a/backend/src/domain/__init__.py
+++ b/backend/src/domain/__init__.py
@@ -3,8 +3,11 @@ Domain layer containing business entities and rules.
 """
 
 from .base import AggregateRoot, DomainException, Entity, ValueObject
-from .entities import Appointment
-from .repositories import AppointmentRepositoryInterface
+from .entities import Appointment, DocumentStatus, PatientDocument
+from .repositories import (
+    AppointmentRepositoryInterface,
+    PatientDocumentRepositoryInterface,
+)
 
 __all__ = [
     "Entity",
@@ -12,5 +15,8 @@ __all__ = [
     "AggregateRoot",
     "DomainException",
     "Appointment",
+    "PatientDocument",
+    "DocumentStatus",
     "AppointmentRepositoryInterface",
+    "PatientDocumentRepositoryInterface",
 ]

--- a/backend/src/domain/entities/__init__.py
+++ b/backend/src/domain/entities/__init__.py
@@ -6,5 +6,13 @@ from .appointment import Appointment
 from .car import Car
 from .collector import Collector
 from .driver import Driver
+from .patient_document import DocumentStatus, PatientDocument
 
-__all__ = ["Appointment", "Car", "Collector", "Driver"]
+__all__ = [
+    "Appointment",
+    "Car",
+    "Collector",
+    "DocumentStatus",
+    "Driver",
+    "PatientDocument",
+]

--- a/backend/src/domain/entities/patient_document.py
+++ b/backend/src/domain/entities/patient_document.py
@@ -1,0 +1,99 @@
+"""Patient document entity and status definitions."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+from pydantic import Field, field_validator
+
+from src.domain.base import Entity
+
+
+class DocumentStatus(str, Enum):
+    """Possible lifecycle states for a patient document."""
+
+    PENDING = "pending"
+    AVAILABLE = "available"
+    SOFT_DELETED = "soft_deleted"
+    HARD_DELETED = "hard_deleted"
+
+
+class PatientDocument(Entity):
+    """Metadata for a patient document stored in Cloudflare R2."""
+
+    appointment_id: str = Field(..., description="ID do agendamento associado")
+    tenant_id: str = Field(..., description="Tenant ao qual o documento pertence")
+    patient_id: str = Field(..., description="Identificador lógico do paciente")
+    original_file_name: str = Field(
+        ..., description="Nome original do arquivo enviado pelo usuário"
+    )
+    sanitized_file_name: str = Field(
+        ..., description="Nome do arquivo sanitizado utilizado no storage"
+    )
+    content_type: str = Field(..., description="MIME type do arquivo")
+    file_size: int = Field(..., description="Tamanho do arquivo em bytes")
+    storage_key: str = Field(..., description="Chave completa utilizada no bucket")
+    bucket: Optional[str] = Field(
+        None, description="Nome do bucket onde o arquivo está armazenado"
+    )
+    status: DocumentStatus = Field(
+        default=DocumentStatus.PENDING,
+        description="Status atual do documento",
+    )
+    uploader_user_id: Optional[str] = Field(
+        None, description="Usuário responsável pelo upload"
+    )
+    source_ip: Optional[str] = Field(
+        None, description="Origem do upload para auditoria"
+    )
+    uploaded_at: Optional[datetime] = Field(
+        None, description="Data de confirmação do upload"
+    )
+    deleted_at: Optional[datetime] = Field(
+        None, description="Data de deleção lógica"
+    )
+    deleted_by: Optional[str] = Field(
+        None, description="Usuário que realizou a deleção lógica"
+    )
+    hard_deleted_at: Optional[datetime] = Field(
+        None, description="Data de remoção física no storage"
+    )
+    etag: Optional[str] = Field(
+        None, description="ETag retornado pelo storage durante o upload"
+    )
+
+    @field_validator("file_size")
+    @classmethod
+    def validate_file_size(cls, value: int) -> int:
+        """Ensure file size is positive."""
+
+        if value <= 0:
+            raise ValueError("Tamanho do arquivo deve ser maior que zero")
+        return value
+
+    def mark_uploaded(self, *, uploaded_at: datetime, etag: Optional[str]) -> None:
+        """Mark the document as fully uploaded and available."""
+
+        self.status = DocumentStatus.AVAILABLE
+        self.uploaded_at = uploaded_at
+        self.etag = etag
+        self.mark_as_updated()
+
+    def mark_soft_deleted(self, *, deleted_at: datetime, user_id: str) -> None:
+        """Perform a soft delete on the document."""
+
+        self.status = DocumentStatus.SOFT_DELETED
+        self.deleted_at = deleted_at
+        self.deleted_by = user_id
+        self.mark_as_updated()
+
+    def mark_hard_deleted(self, *, deleted_at: datetime, user_id: str) -> None:
+        """Mark the document as permanently deleted."""
+
+        self.status = DocumentStatus.HARD_DELETED
+        self.deleted_at = deleted_at
+        self.deleted_by = user_id
+        self.hard_deleted_at = deleted_at
+        self.mark_as_updated()

--- a/backend/src/domain/repositories/__init__.py
+++ b/backend/src/domain/repositories/__init__.py
@@ -6,10 +6,14 @@ from .appointment_repository_interface import AppointmentRepositoryInterface
 from .car_repository_interface import CarRepositoryInterface
 from .collector_repository_interface import CollectorRepositoryInterface
 from .driver_repository_interface import DriverRepositoryInterface
+from .patient_document_repository_interface import (
+    PatientDocumentRepositoryInterface,
+)
 
 __all__ = [
     "AppointmentRepositoryInterface",
     "CarRepositoryInterface",
     "CollectorRepositoryInterface",
+    "PatientDocumentRepositoryInterface",
     "DriverRepositoryInterface",
 ]

--- a/backend/src/domain/repositories/patient_document_repository_interface.py
+++ b/backend/src/domain/repositories/patient_document_repository_interface.py
@@ -1,0 +1,36 @@
+"""Repository interface for patient documents."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import List, Optional
+
+from src.domain.entities.patient_document import PatientDocument
+
+
+class PatientDocumentRepositoryInterface(ABC):
+    """Contract for patient document persistence operations."""
+
+    @abstractmethod
+    async def create(self, document: PatientDocument) -> PatientDocument:
+        """Persist a new patient document metadata entry."""
+
+    @abstractmethod
+    async def update(self, document: PatientDocument) -> PatientDocument:
+        """Persist updates to an existing document."""
+
+    @abstractmethod
+    async def find_by_id(
+        self, document_id: str, tenant_id: str
+    ) -> Optional[PatientDocument]:
+        """Fetch a document by identifier scoped to a tenant."""
+
+    @abstractmethod
+    async def list_by_appointment(
+        self, appointment_id: str, tenant_id: str, include_deleted: bool = False
+    ) -> List[PatientDocument]:
+        """Return documents linked to an appointment."""
+
+    @abstractmethod
+    async def create_indexes(self) -> None:
+        """Ensure required indexes exist in the persistence layer."""

--- a/backend/src/infrastructure/repositories/__init__.py
+++ b/backend/src/infrastructure/repositories/__init__.py
@@ -1,7 +1,15 @@
-"""
-Infrastructure repository implementations.
-"""
+"""Infrastructure repository implementations."""
 
 from .appointment_repository import AppointmentRepository
+from .car_repository import CarRepository
+from .collector_repository import CollectorRepository
+from .driver_repository import DriverRepository
+from .patient_document_repository import PatientDocumentRepository
 
-__all__ = ["AppointmentRepository"]
+__all__ = [
+    "AppointmentRepository",
+    "CarRepository",
+    "CollectorRepository",
+    "DriverRepository",
+    "PatientDocumentRepository",
+]

--- a/backend/src/infrastructure/repositories/patient_document_repository.py
+++ b/backend/src/infrastructure/repositories/patient_document_repository.py
@@ -1,0 +1,96 @@
+"""MongoDB repository for patient documents."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from motor.motor_asyncio import AsyncIOMotorDatabase
+from pymongo import ASCENDING, DESCENDING, ReturnDocument
+
+from src.domain.entities.patient_document import DocumentStatus, PatientDocument
+from src.domain.repositories.patient_document_repository_interface import (
+    PatientDocumentRepositoryInterface,
+)
+
+
+class PatientDocumentRepository(PatientDocumentRepositoryInterface):
+    """MongoDB implementation for storing patient document metadata."""
+
+    def __init__(self, database: AsyncIOMotorDatabase) -> None:
+        self.database = database
+        self.collection = database.patient_documents
+
+    async def create_indexes(self) -> None:
+        """Create indexes required for common access patterns."""
+
+        await self.collection.create_index(
+            [
+                ("tenant_id", ASCENDING),
+                ("appointment_id", ASCENDING),
+                ("status", ASCENDING),
+            ],
+            name="tenant_appointment_status_idx",
+        )
+        await self.collection.create_index(
+            [("tenant_id", ASCENDING), ("id", ASCENDING)],
+            unique=True,
+            name="tenant_document_unique_idx",
+        )
+
+    async def create(self, document: PatientDocument) -> PatientDocument:
+        data = document.model_dump()
+        data["id"] = str(document.id)
+        await self.collection.insert_one(data)
+        return document
+
+    async def update(self, document: PatientDocument) -> PatientDocument:
+        data = document.model_dump()
+        data["id"] = str(document.id)
+
+        updated = await self.collection.find_one_and_update(
+            {"id": str(document.id), "tenant_id": document.tenant_id},
+            {"$set": data},
+            return_document=ReturnDocument.AFTER,
+        )
+
+        if updated is None:
+            return document
+
+        updated.pop("_id", None)
+        return PatientDocument(**updated)
+
+    async def find_by_id(
+        self, document_id: str, tenant_id: str
+    ) -> Optional[PatientDocument]:
+        doc = await self.collection.find_one(
+            {"id": document_id, "tenant_id": tenant_id}
+        )
+        if doc is None:
+            return None
+
+        doc.pop("_id", None)
+        return PatientDocument(**doc)
+
+    async def list_by_appointment(
+        self, appointment_id: str, tenant_id: str, include_deleted: bool = False
+    ) -> List[PatientDocument]:
+        query: dict[str, object] = {
+            "appointment_id": appointment_id,
+            "tenant_id": tenant_id,
+        }
+
+        if not include_deleted:
+            query["status"] = {
+                "$nin": [
+                    DocumentStatus.SOFT_DELETED.value,
+                    DocumentStatus.HARD_DELETED.value,
+                ]
+            }
+
+        cursor = self.collection.find(query).sort("created_at", DESCENDING)
+        documents: List[PatientDocument] = []
+        async for doc in cursor:
+            doc.pop("_id", None)
+            documents.append(PatientDocument(**doc))
+
+        return documents

--- a/backend/src/infrastructure/storage/r2_client.py
+++ b/backend/src/infrastructure/storage/r2_client.py
@@ -1,0 +1,81 @@
+"""Utility client for interacting with Cloudflare R2 using boto3."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Dict, Optional
+
+import boto3
+from botocore.client import Config
+
+from src.infrastructure.config import Settings
+
+
+class R2StorageClient:
+    """Minimal wrapper around boto3 for generating presigned URLs."""
+
+    def __init__(self, settings: Settings) -> None:
+        self._settings = settings
+        self._client = self._build_client()
+
+    def _build_client(self):
+        endpoint = self._settings.r2_endpoint_url
+        session = boto3.session.Session()
+        return session.client(
+            "s3",
+            endpoint_url=endpoint,
+            aws_access_key_id=self._settings.r2_access_key_id,
+            aws_secret_access_key=self._settings.r2_secret_access_key,
+            region_name="auto",
+            config=Config(signature_version="s3v4"),
+        )
+
+    @property
+    def bucket(self) -> str:
+        bucket = self._settings.r2_bucket_patient_docs
+        if not bucket:
+            raise ValueError("R2_BUCKET_PATIENT_DOCS não está configurado")
+        return bucket
+
+    def generate_presigned_put(
+        self,
+        *,
+        key: str,
+        content_type: str,
+        expires_in: Optional[int] = None,
+        extra_headers: Optional[Dict[str, str]] = None,
+    ) -> Dict[str, object]:
+        """Generate a presigned PUT URL for direct uploads."""
+
+        params = {
+            "Bucket": self.bucket,
+            "Key": key,
+            "ContentType": content_type,
+        }
+        if extra_headers:
+            params.update(extra_headers)
+
+        url = self._client.generate_presigned_url(
+            "put_object",
+            Params=params,
+            ExpiresIn=expires_in or self._settings.r2_presign_ttl_seconds,
+        )
+        return {"url": url, "headers": {"Content-Type": content_type}}
+
+    def generate_presigned_get(
+        self, *, key: str, expires_in: Optional[int] = None
+    ) -> str:
+        """Generate a presigned GET URL for temporary downloads."""
+
+        return self._client.generate_presigned_url(
+            "get_object",
+            Params={"Bucket": self.bucket, "Key": key},
+            ExpiresIn=expires_in or self._settings.r2_presign_ttl_seconds,
+        )
+
+    async def delete_object(self, *, key: str) -> None:
+        """Delete an object from the bucket asynchronously."""
+
+        await asyncio.to_thread(
+            self._client.delete_object, Bucket=self.bucket, Key=key
+        )

--- a/backend/src/presentation/api/v1/endpoints/appointment_documents.py
+++ b/backend/src/presentation/api/v1/endpoints/appointment_documents.py
@@ -1,0 +1,141 @@
+"""API endpoints for managing patient documents linked to appointments."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Path, Query, status
+
+from src.application.dtos.patient_document_dto import (
+    ConfirmUploadRequestDTO,
+    DownloadUrlResponseDTO,
+    PatientDocumentDTO,
+    PatientDocumentListResponseDTO,
+    PresignUploadRequestDTO,
+    PresignUploadResponseDTO,
+)
+from src.application.services.patient_document_service import PatientDocumentService
+from src.infrastructure.container import (
+    get_app_settings,
+    get_patient_document_repository,
+    get_r2_storage_client,
+)
+from src.presentation.api.responses import DataResponse
+from src.presentation.dependencies import get_request_context
+
+router = APIRouter(
+    prefix="/appointments/{appointment_id}/documents",
+    tags=["Appointment Documents"],
+)
+
+
+async def get_patient_document_service() -> PatientDocumentService:
+    repository = await get_patient_document_repository()
+    storage = await get_r2_storage_client()
+    settings = await get_app_settings()
+    return PatientDocumentService(repository, storage, settings)
+
+
+@router.post(
+    "/presign",
+    response_model=DataResponse[PresignUploadResponseDTO],
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_document_presign_url(
+    payload: PresignUploadRequestDTO,
+    appointment_id: str = Path(..., description="ID do agendamento"),
+    service: PatientDocumentService = Depends(get_patient_document_service),
+    context=Depends(get_request_context),
+) -> DataResponse[PresignUploadResponseDTO]:
+    """Return a presigned URL for uploading a new document."""
+
+    result = await service.create_presigned_upload(
+        appointment_id=appointment_id,
+        payload=payload,
+        context=context,
+    )
+    return DataResponse(
+        data=result,
+        message="URL pré-assinada gerada com sucesso",
+    )
+
+
+@router.post(
+    "/{document_id}/confirm",
+    response_model=DataResponse[PatientDocumentDTO],
+)
+async def confirm_document_upload(
+    payload: ConfirmUploadRequestDTO,
+    appointment_id: str = Path(..., description="ID do agendamento"),
+    document_id: str = Path(..., description="ID do documento"),
+    service: PatientDocumentService = Depends(get_patient_document_service),
+    context=Depends(get_request_context),
+) -> DataResponse[PatientDocumentDTO]:
+    """Mark a document upload as complete after PUT to storage."""
+
+    document = await service.confirm_upload(
+        appointment_id=appointment_id,
+        document_id=document_id,
+        payload=payload,
+        context=context,
+    )
+    return DataResponse(data=document, message="Upload confirmado com sucesso")
+
+
+@router.get(
+    "",
+    response_model=DataResponse[PatientDocumentListResponseDTO],
+)
+async def list_documents(
+    appointment_id: str = Path(..., description="ID do agendamento"),
+    service: PatientDocumentService = Depends(get_patient_document_service),
+    context=Depends(get_request_context),
+) -> DataResponse[PatientDocumentListResponseDTO]:
+    """List active documents for a specific appointment."""
+
+    documents = await service.list_documents(
+        appointment_id=appointment_id,
+        context=context,
+    )
+    return DataResponse(data=documents)
+
+
+@router.get(
+    "/{document_id}/download",
+    response_model=DataResponse[DownloadUrlResponseDTO],
+)
+async def get_download_url(
+    appointment_id: str = Path(..., description="ID do agendamento"),
+    document_id: str = Path(..., description="ID do documento"),
+    service: PatientDocumentService = Depends(get_patient_document_service),
+    context=Depends(get_request_context),
+) -> DataResponse[DownloadUrlResponseDTO]:
+    """Generate a temporary download URL for a document."""
+
+    download = await service.create_download_url(
+        appointment_id=appointment_id,
+        document_id=document_id,
+        context=context,
+    )
+    return DataResponse(data=download)
+
+
+@router.delete(
+    "/{document_id}",
+    response_model=DataResponse[PatientDocumentDTO],
+)
+async def delete_document(
+    appointment_id: str = Path(..., description="ID do agendamento"),
+    document_id: str = Path(..., description="ID do documento"),
+    hard: bool = Query(False, description="Define se a exclusão será definitiva"),
+    service: PatientDocumentService = Depends(get_patient_document_service),
+    context=Depends(get_request_context),
+) -> DataResponse[PatientDocumentDTO]:
+    """Soft delete by default, or hard delete when requested by admins."""
+
+    document = await service.delete_document(
+        appointment_id=appointment_id,
+        document_id=document_id,
+        hard_delete=hard,
+        context=context,
+    )
+    message = "Documento removido permanentemente" if hard else "Documento removido"
+    return DataResponse(data=document, message=message)

--- a/backend/src/presentation/api/v1/router.py
+++ b/backend/src/presentation/api/v1/router.py
@@ -10,6 +10,7 @@ from src.infrastructure.config import get_settings
 
 # Import and include routers
 from src.presentation.api.v1.endpoints import (
+    appointment_documents,
     appointments,
     cars,
     collectors,
@@ -30,6 +31,7 @@ api_v1_router = APIRouter(
 api_v1_router.include_router(
     appointments.router, prefix="/appointments", tags=["Appointments"]
 )
+api_v1_router.include_router(appointment_documents.router)
 
 api_v1_router.include_router(
     drivers.router, prefix="/drivers", tags=["Drivers"]
@@ -56,6 +58,9 @@ async def api_v1_root() -> dict[str, Any]:
             "docs": f"{settings.api_v1_prefix}/docs",
             "health": f"{settings.api_v1_prefix}/health",
             "appointments": f"{settings.api_v1_prefix}/appointments",
+            "appointment_documents": (
+                f"{settings.api_v1_prefix}/appointments/{{appointment_id}}/documents"
+            ),
             "drivers": f"{settings.api_v1_prefix}/drivers",
             "collectors": f"{settings.api_v1_prefix}/collectors",
             "cars": f"{settings.api_v1_prefix}/cars",

--- a/backend/src/presentation/dependencies/__init__.py
+++ b/backend/src/presentation/dependencies/__init__.py
@@ -1,0 +1,5 @@
+"""Reusable dependency providers for FastAPI routes."""
+
+from .context import get_request_context
+
+__all__ = ["get_request_context"]

--- a/backend/src/presentation/dependencies/context.py
+++ b/backend/src/presentation/dependencies/context.py
@@ -1,0 +1,34 @@
+"""FastAPI dependency helpers for request context extraction."""
+
+from __future__ import annotations
+
+from fastapi import HTTPException, Request, status
+
+from src.application.common import RequestContext, UserRole
+
+
+async def get_request_context(request: Request) -> RequestContext:
+    """Build a RequestContext object from headers and connection info."""
+
+    user_id = request.headers.get("X-User-Id") or "system"
+    tenant_id = request.headers.get("X-Tenant-Id") or "default"
+    role_header = request.headers.get("X-User-Role") or UserRole.COLLABORATOR.value
+
+    try:
+        role = UserRole(role_header.lower())
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Perfil de usuário inválido",
+        ) from exc
+
+    source_ip = request.headers.get("X-Forwarded-For")
+    if not source_ip and request.client:
+        source_ip = request.client.host
+
+    return RequestContext(
+        user_id=user_id,
+        tenant_id=tenant_id,
+        role=role,
+        source_ip=source_ip,
+    )

--- a/docs/features/docs/patient-docs-r2.md
+++ b/docs/features/docs/patient-docs-r2.md
@@ -1,0 +1,86 @@
+# Patient Documents via Cloudflare R2
+
+## Executive Summary
+- Introduces document management per appointment with metadata stored in MongoDB and files stored in Cloudflare R2 (or any S3-compatible storage).
+- Adds API endpoints for upload presign, confirmation, listing, download, and deletion with tenant-aware authorization and auditing fields.
+- Extends the appointment detail experience in the frontend with a document panel (drag & drop upload, listing, download, soft/hard delete) available from cards, agenda, and calendar views.
+- Documents rollout strategy covering local tests (MinIO or R2) and promotion to Coolify environments.
+
+## Architecture Overview
+1. **Presigned Upload Flow**
+   - Client requests `POST /appointments/{appointmentId}/documents/presign` with filename, MIME type, and size.
+   - Backend validates tenant/role, allowed MIME types, and size, persists a `pending` document metadata row, and returns a presigned PUT URL to R2.
+   - Client uploads directly to R2 using the provided URL, then calls `POST /appointments/{appointmentId}/documents/{documentId}/confirm` with the final size/ETag. The record transitions to `available`.
+2. **Storage Key Convention**
+   - `patients/{patientId}/appointments/{appointmentId}/{yyyy}/{mm}/{uuid}_{sanitizedName}` (patientId derived client-side and sanitized server-side).
+3. **Document Retrieval & Removal**
+   - `GET /appointments/{appointmentId}/documents` lists non-deleted documents.
+   - `GET /appointments/{appointmentId}/documents/{documentId}/download` issues a presigned GET URL (default TTL 600s).
+   - `DELETE /appointments/{appointmentId}/documents/{documentId}?hard=true|false` performs soft-delete (default) or hard-delete (admin only; also deletes from R2).
+4. **Security & Auditing**
+   - Requires tenant/user context from headers (`X-User-Id`, `X-User-Role`, `X-Tenant-Id`).
+   - Metadata captures `uploaderUserId`, `sourceIP`, timestamps, and deletion actors.
+5. **Frontend**
+   - A slide-over drawer allows uploads (drag & drop), shows upload status, lists documents, and exposes download/delete actions.
+   - Accessible from appointment cards, agenda view, and calendar day modal.
+
+## Environment Variables
+| Variable | Description |
+| --- | --- |
+| `R2_ACCOUNT_ID` | Cloudflare account ID (or empty when using custom S3 endpoint). |
+| `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` | Credentials for the bucket. |
+| `R2_BUCKET_PATIENT_DOCS` | Bucket name dedicated to patient documents. |
+| `R2_PRESIGN_TTL_SECONDS` | TTL (seconds) for presigned URLs (default 600). |
+| `MAX_UPLOAD_MB` | Max upload size for patient docs (default 10 MB). |
+| `ALLOWED_MIME_LIST` | Comma-separated allowed MIME types (default PDF/JPEG/PNG/WEBP/HEIC). |
+| `S3_ENDPOINT` | Optional override (e.g., `http://localhost:9000` for MinIO). |
+| Frontend: `VITE_API_USER_ID`, `VITE_API_USER_ROLE`, `VITE_API_TENANT_ID`, `VITE_PATIENT_DOCS_MAX_MB`, `VITE_PATIENT_DOCS_ALLOWED_MIME`. |
+
+## Local Testing Plan
+### A. Using MinIO
+1. Start MinIO locally (`docker run -p 9000:9000 -p 9001:9001 ...`).
+2. Create bucket `patient-docs` and apply CORS allowing `http://localhost:*`, methods `PUT,GET`, headers `*`, expose `ETag`.
+3. Configure backend `.env.local`:
+   - `S3_ENDPOINT=http://localhost:9000`
+   - MinIO access/secret keys, `R2_BUCKET_PATIENT_DOCS=patient-docs`.
+4. Configure frontend `.env.local` to point at backend (`VITE_API_URL=http://localhost:8000` etc.).
+5. Flow checklist:
+   - Presign -> PUT upload -> confirm -> list -> download -> delete (soft/hard) using the UI.
+   - Validate: PDF/JPG ≤10 MB succeeds; MIME outside `ALLOWED_MIME_LIST` returns 400; download URL expires after ~10 minutes; soft-deleted docs disappear from list; hard delete removes object from MinIO (verify via MinIO console).
+
+### B. Using Cloudflare R2 Directly
+1. Create R2 bucket and S3 API token pair (separate keys per environment). Note default endpoint `https://<account_id>.r2.cloudflarestorage.com`.
+2. Apply CORS for `http://localhost:3000` and `http://localhost:5173` during dev.
+3. Configure backend `.env.local.r2` with account ID, keys, bucket name, TTL, and clear `S3_ENDPOINT`.
+4. Repeat the same functional checklist as MinIO to validate end-to-end behaviour.
+
+## Promotion to Coolify + R2
+1. **Coolify App Setup**
+   - Add backend service with healthcheck `/health` and set environment variables identical to `.env.staging` or `.env.prod` (include R2 credentials, bucket, TTL, allowed MIME).
+   - Frontend service should include mock headers (or integrate actual auth when available) so the API receives tenant/user context.
+2. **R2 Configuration**
+   - Create buckets for staging and production.
+   - Configure CORS to include `https://clinica-staging.widia.io` and `https://clinica.widia.io` (plus backend domains if required).
+   - Issue dedicated access keys per environment (principle of least privilege).
+3. **Smoke Tests After Deployment**
+   - Upload a valid PDF/image via UI; confirm metadata stored and file visible in R2 console.
+   - Validate list and download link expiration (~10 minutes).
+   - Execute soft-delete (document disappears from UI) and hard-delete (object removed from bucket) as admin.
+   - Ensure collaborator role cannot hard-delete (API returns 403) and that tenant isolation works by using different headers.
+
+## Acceptance Checklist
+- [ ] Backend endpoints respond with correct status codes and payloads for happy path and validation errors.
+- [ ] Presigned upload + confirmation persists metadata and makes download available.
+- [ ] Soft delete hides document without removing from storage; hard delete removes from storage and marks record.
+- [ ] Frontend dropzone enforces size/type limits and surfaces errors.
+- [ ] Document drawer accessible from cards, calendar modal, and agenda views.
+- [ ] Audit fields (`uploaderUserId`, `sourceIP`, timestamps) populate in database.
+- [ ] `.env.example` and frontend `.env.example` include new variables.
+- [ ] Documentation (this file) reviewed and linked in release notes.
+
+## Definition of Done
+- Code merged with automated tests passing and manual smoke checklist completed.
+- Documentation updated (architecture, env vars, rollout steps).
+- Feature toggled in staging with successful smoke test before production rollout.
+- Monitoring/alerts (if applicable) configured for upload errors.
+- Stakeholders (ops/support) informed about new env vars and manual validation steps.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,2 +1,11 @@
 # Backend API URL
 VITE_API_URL=http://localhost:8000
+
+# Mock authentication context for local development
+VITE_API_USER_ID=dev-user
+VITE_API_USER_ROLE=admin
+VITE_API_TENANT_ID=dev-tenant
+
+# Patient document upload hints for the frontend UI
+VITE_PATIENT_DOCS_MAX_MB=10
+VITE_PATIENT_DOCS_ALLOWED_MIME=application/pdf,image/jpeg,image/png,image/webp,image/heic

--- a/frontend/src/components/AppointmentCalendarView.tsx
+++ b/frontend/src/components/AppointmentCalendarView.tsx
@@ -21,6 +21,7 @@ export const AppointmentCalendarView: React.FC<CalendarViewProps> = ({
   onAppointmentDriverChange,
   onAppointmentCollectorChange,
   onAppointmentDelete,
+  onAppointmentViewDetails,
   drivers = [],
   collectors = [],
   isLoading = false,
@@ -164,6 +165,7 @@ export const AppointmentCalendarView: React.FC<CalendarViewProps> = ({
           onDelete={onAppointmentDelete}
           drivers={drivers}
           collectors={collectors}
+          onViewDetails={onAppointmentViewDetails}
         />
       )}
     </div>

--- a/frontend/src/components/AppointmentCard.tsx
+++ b/frontend/src/components/AppointmentCard.tsx
@@ -3,6 +3,7 @@ import {
     CalendarIcon,
     ClockIcon,
     CreditCardIcon,
+    DocumentTextIcon,
     IdentificationIcon,
     PhoneIcon,
     TrashIcon,
@@ -27,6 +28,7 @@ interface AppointmentCardProps {
   onCollectorChange?: (appointmentId: string, collectorId: string) => void;
   onCarChange?: (appointmentId: string, carId: string) => void;
   onDelete: (id: string) => void;
+  onViewDetails?: (appointment: Appointment) => void;
   compact?: boolean;
 }
 
@@ -49,6 +51,7 @@ export const AppointmentCard: React.FC<AppointmentCardProps> = ({
   onCollectorChange,
   onCarChange,
   onDelete,
+  onViewDetails,
   compact = false
 }) => {
   // Get car info from linked car or carro field
@@ -212,6 +215,19 @@ export const AppointmentCard: React.FC<AppointmentCardProps> = ({
           </div>
         )}
       </div>
+
+      {onViewDetails && (
+        <div className="mt-4 flex justify-end">
+          <button
+            type="button"
+            onClick={() => onViewDetails(appointment)}
+            className="inline-flex items-center space-x-2 rounded-md border border-indigo-200 bg-indigo-50 px-3 py-2 text-sm font-medium text-indigo-700 hover:bg-indigo-100"
+          >
+            <DocumentTextIcon className="w-4 h-4" />
+            <span>Documentos</span>
+          </button>
+        </div>
+      )}
 
       {/* Footer */}
       <div className="mt-4 pt-3 border-t border-gray-100">

--- a/frontend/src/components/AppointmentCardList.tsx
+++ b/frontend/src/components/AppointmentCardList.tsx
@@ -14,6 +14,7 @@ interface AppointmentCardListProps {
   onDriverChange: (appointmentId: string, driverId: string) => void;
   onCollectorChange?: (appointmentId: string, collectorId: string) => void;
   onDelete: (id: string) => void;
+  onViewDetails?: (appointment: Appointment) => void;
 }
 
 const CardSkeleton: React.FC = () => (
@@ -42,7 +43,8 @@ export const AppointmentCardList: React.FC<AppointmentCardListProps> = ({
   onStatusChange,
   onDriverChange,
   onCollectorChange,
-  onDelete
+  onDelete,
+  onViewDetails
 }) => {
   const { isMobile, isTablet } = useResponsiveLayout();
 
@@ -88,6 +90,7 @@ export const AppointmentCardList: React.FC<AppointmentCardListProps> = ({
           onDriverChange={onDriverChange}
           onCollectorChange={onCollectorChange}
           onDelete={onDelete}
+          onViewDetails={onViewDetails}
           compact={isMobile}
         />
       ))}

--- a/frontend/src/components/AppointmentDetailDrawer.tsx
+++ b/frontend/src/components/AppointmentDetailDrawer.tsx
@@ -1,0 +1,499 @@
+import { Dialog, Transition } from '@headlessui/react';
+import {
+  ArrowDownTrayIcon,
+  CloudArrowUpIcon,
+  DocumentIcon,
+  ExclamationTriangleIcon,
+  TrashIcon,
+  XMarkIcon,
+} from '@heroicons/react/24/outline';
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import type { Appointment } from '../types/appointment';
+import type { PatientDocument } from '../types/patientDocument';
+import { appointmentAPI } from '../services/api';
+
+interface AppointmentDetailDrawerProps {
+  appointment: Appointment | null;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const role = (import.meta.env.VITE_API_USER_ROLE ?? 'admin').toLowerCase();
+const maxUploadMb = Number(import.meta.env.VITE_PATIENT_DOCS_MAX_MB ?? 10);
+const allowedMime = (import.meta.env.VITE_PATIENT_DOCS_ALLOWED_MIME ?? 'application/pdf,image/jpeg,image/png,image/webp,image/heic')
+  .split(',')
+  .map((mime) => mime.trim());
+
+const formatBytes = (size: number): string => {
+  if (!size) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB'];
+  const index = Math.min(Math.floor(Math.log(size) / Math.log(1024)), units.length - 1);
+  const value = size / Math.pow(1024, index);
+  return `${value.toFixed(value >= 10 || index === 0 ? 0 : 1)} ${units[index]}`;
+};
+
+const formatDateTime = (value?: string | null): string => {
+  if (!value) return '-';
+  try {
+    const date = new Date(value);
+    return date.toLocaleString('pt-BR');
+  } catch {
+    return value;
+  }
+};
+
+const derivePatientId = (appointment: Appointment): string => {
+  const cpf = appointment.documento_normalizado?.cpf || appointment.cpf;
+  if (cpf) {
+    return cpf.replace(/[^0-9a-zA-Z]/g, '');
+  }
+
+  return appointment.nome_paciente
+    .normalize('NFD')
+    .replace(/[^\w\s-]/g, '')
+    .trim()
+    .replace(/\s+/g, '-')
+    .toLowerCase();
+};
+
+export const AppointmentDetailDrawer: React.FC<AppointmentDetailDrawerProps> = ({
+  appointment,
+  isOpen,
+  onClose,
+}) => {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const [isUploading, setIsUploading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [workingDocumentId, setWorkingDocumentId] = useState<string | null>(null);
+
+  const appointmentId = appointment?.id;
+
+  const documentsQuery = useQuery({
+    queryKey: ['appointmentDocuments', appointmentId],
+    queryFn: () => appointmentAPI.getAppointmentDocuments(appointmentId!),
+    enabled: isOpen && Boolean(appointmentId),
+    refetchOnWindowFocus: false,
+  });
+
+  useEffect(() => {
+    if (!isOpen) {
+      setErrorMessage(null);
+      setSuccessMessage(null);
+      setIsDragging(false);
+      setWorkingDocumentId(null);
+    }
+  }, [isOpen]);
+
+  const documents = useMemo<PatientDocument[]>(() => {
+    return documentsQuery.data?.documents ?? [];
+  }, [documentsQuery.data]);
+
+  const handleFiles = useCallback(
+    async (files: FileList | File[]) => {
+      if (!appointment) {
+        return;
+      }
+
+      const patientId = derivePatientId(appointment);
+
+      setErrorMessage(null);
+      setSuccessMessage(null);
+      setIsUploading(true);
+
+      for (const file of Array.from(files)) {
+        if (file.size > maxUploadMb * 1024 * 1024) {
+          setErrorMessage(
+            `Arquivo "${file.name}" excede o limite de ${maxUploadMb}MB.`
+          );
+          continue;
+        }
+
+        const contentType = file.type || 'application/octet-stream';
+
+        try {
+          const presign = await appointmentAPI.presignDocumentUpload(
+            appointment.id,
+            {
+              patient_id: patientId,
+              file_name: file.name,
+              content_type: contentType,
+              file_size: file.size,
+            }
+          );
+
+          const uploadResponse = await fetch(presign.upload_url, {
+            method: 'PUT',
+            headers: {
+              'Content-Type': contentType,
+              ...presign.headers,
+            },
+            body: file,
+          });
+
+          if (!uploadResponse.ok) {
+            throw new Error(
+              `Falha ao enviar arquivo (${uploadResponse.status})`
+            );
+          }
+
+          const etag =
+            uploadResponse.headers.get('ETag') ??
+            uploadResponse.headers.get('etag') ??
+            undefined;
+
+          await appointmentAPI.confirmDocumentUpload(
+            appointment.id,
+            presign.document_id,
+            {
+              file_size: file.size,
+              etag,
+            }
+          );
+
+          setSuccessMessage(`Upload de "${file.name}" concluído.`);
+          await documentsQuery.refetch();
+        } catch (error) {
+          console.error(error);
+          setErrorMessage(
+            error instanceof Error
+              ? error.message
+              : `Falha no upload de "${file.name}".`
+          );
+        }
+      }
+
+      setIsUploading(false);
+    },
+    [appointment, documentsQuery]
+  );
+
+  const handleInputChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const files = event.target.files;
+      if (files) {
+        void handleFiles(files);
+        event.target.value = '';
+      }
+    },
+    [handleFiles]
+  );
+
+  const handleDrop = useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      setIsDragging(false);
+      if (event.dataTransfer.files?.length) {
+        void handleFiles(event.dataTransfer.files);
+      }
+    },
+    [handleFiles]
+  );
+
+  const handleDragOver = useCallback((event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setIsDragging(true);
+  }, []);
+
+  const handleDragLeave = useCallback((event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setIsDragging(false);
+  }, []);
+
+  const handleDownload = useCallback(
+    async (document: PatientDocument) => {
+      if (!appointment) return;
+      setWorkingDocumentId(document.id);
+      try {
+        const download = await appointmentAPI.getDocumentDownloadUrl(
+          appointment.id,
+          document.id
+        );
+        window.open(download.url, '_blank', 'noopener');
+      } catch (error) {
+        console.error(error);
+        setErrorMessage('Não foi possível gerar o link de download.');
+      } finally {
+        setWorkingDocumentId(null);
+      }
+    },
+    [appointment]
+  );
+
+  const handleDelete = useCallback(
+    async (document: PatientDocument, hard = false) => {
+      if (!appointment) return;
+
+      if (
+        hard &&
+        !confirm('Tem certeza que deseja remover permanentemente este documento?')
+      ) {
+        return;
+      }
+
+      setWorkingDocumentId(document.id);
+      setErrorMessage(null);
+      setSuccessMessage(null);
+
+      try {
+        await appointmentAPI.deleteDocument(
+          appointment.id,
+          document.id,
+          hard
+        );
+        setSuccessMessage('Documento removido com sucesso.');
+        await documentsQuery.refetch();
+      } catch (error) {
+        console.error(error);
+        setErrorMessage(
+          hard
+            ? 'Falha ao remover permanentemente o documento.'
+            : 'Falha ao remover o documento.'
+        );
+      } finally {
+        setWorkingDocumentId(null);
+      }
+    },
+    [appointment, documentsQuery]
+  );
+
+  if (!appointment) {
+    return null;
+  }
+
+  const canHardDelete = role === 'admin';
+
+  return (
+    <Transition show={isOpen} as={Fragment}>
+      <Dialog as="div" className="relative z-50" onClose={onClose}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-black/30" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 overflow-hidden">
+          <div className="absolute inset-0 overflow-hidden">
+            <div className="pointer-events-none fixed inset-y-0 right-0 flex max-w-full pl-10">
+              <Transition.Child
+                as={Fragment}
+                enter="transform transition ease-in-out duration-300"
+                enterFrom="translate-x-full"
+                enterTo="translate-x-0"
+                leave="transform transition ease-in-out duration-300"
+                leaveFrom="translate-x-0"
+                leaveTo="translate-x-full"
+              >
+                <Dialog.Panel className="pointer-events-auto w-screen max-w-2xl">
+                  <div className="flex h-full flex-col overflow-y-scroll bg-white shadow-xl">
+                    <div className="px-6 py-4 border-b border-gray-200 flex items-start justify-between">
+                      <div>
+                        <Dialog.Title className="text-lg font-semibold text-gray-900">
+                          {appointment.nome_paciente}
+                        </Dialog.Title>
+                        <p className="text-sm text-gray-500 mt-1">
+                          {appointment.nome_unidade} • {appointment.nome_marca}
+                        </p>
+                        <p className="text-sm text-gray-500">
+                          {new Date(appointment.data_agendamento).toLocaleDateString('pt-BR')} às {appointment.hora_agendamento}
+                        </p>
+                      </div>
+                      <button
+                        type="button"
+                        className="rounded-md text-gray-400 hover:text-gray-500"
+                        onClick={onClose}
+                      >
+                        <span className="sr-only">Fechar</span>
+                        <XMarkIcon className="h-6 w-6" aria-hidden="true" />
+                      </button>
+                    </div>
+
+                    <div className="px-6 py-4 border-b border-gray-100 bg-gray-50">
+                      <h3 className="text-sm font-medium text-gray-700">Informações do agendamento</h3>
+                      <dl className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm text-gray-600">
+                        <div>
+                          <dt className="font-medium text-gray-500">Convênio</dt>
+                          <dd>
+                            {appointment.nome_convenio
+                              ? `${appointment.nome_convenio}${appointment.numero_convenio ? ` • ${appointment.numero_convenio}` : ''}`
+                              : '-'}
+                          </dd>
+                        </div>
+                        <div>
+                          <dt className="font-medium text-gray-500">Status</dt>
+                          <dd>{appointment.status}</dd>
+                        </div>
+                        <div>
+                          <dt className="font-medium text-gray-500">Telefone</dt>
+                          <dd>{appointment.telefone || '-'}</dd>
+                        </div>
+                        <div>
+                          <dt className="font-medium text-gray-500">Endereço</dt>
+                          <dd>
+                            {appointment.endereco_normalizado?.rua
+                              ? `${appointment.endereco_normalizado.rua}${appointment.endereco_normalizado.numero ? `, ${appointment.endereco_normalizado.numero}` : ''}`
+                              : appointment.endereco_coleta || '-'}
+                          </dd>
+                        </div>
+                      </dl>
+                    </div>
+
+                    <div className="px-6 py-6 flex-1 overflow-y-auto">
+                      <section>
+                        <div className="flex items-center justify-between">
+                          <div className="flex items-center space-x-2">
+                            <DocumentIcon className="h-5 w-5 text-indigo-600" />
+                            <h3 className="text-base font-semibold text-gray-900">Documentos do paciente</h3>
+                          </div>
+                          <button
+                            type="button"
+                            onClick={() => inputRef.current?.click()}
+                            className="inline-flex items-center space-x-2 rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+                            disabled={isUploading}
+                          >
+                            <CloudArrowUpIcon className="h-4 w-4" />
+                            <span>Enviar arquivo</span>
+                          </button>
+                        </div>
+                        <p className="mt-2 text-sm text-gray-500">
+                          Tipos permitidos: {allowedMime.join(', ')} • Até {maxUploadMb}MB por arquivo.
+                        </p>
+
+                        <div
+                          className={`mt-4 border-2 border-dashed rounded-lg p-6 text-center transition-colors ${
+                            isDragging
+                              ? 'border-indigo-400 bg-indigo-50'
+                              : 'border-gray-300 bg-white'
+                          } ${isUploading ? 'opacity-70' : ''}`}
+                          onDragOver={handleDragOver}
+                          onDragLeave={handleDragLeave}
+                          onDrop={handleDrop}
+                        >
+                          <input
+                            ref={inputRef}
+                            type="file"
+                            multiple
+                            className="hidden"
+                            onChange={handleInputChange}
+                            accept={allowedMime.join(',')}
+                          />
+                          <p className="text-sm text-gray-700">
+                            Arraste e solte arquivos aqui ou
+                            <button
+                              type="button"
+                              onClick={() => inputRef.current?.click()}
+                              className="text-indigo-600 font-medium ml-1 hover:underline"
+                              disabled={isUploading}
+                            >
+                              clique para selecionar
+                            </button>
+                          </p>
+                          {isUploading && (
+                            <p className="mt-2 text-sm text-indigo-600">Enviando arquivos...</p>
+                          )}
+                        </div>
+
+                        {errorMessage && (
+                          <div className="mt-4 flex items-start space-x-2 rounded-md bg-red-50 p-3 text-sm text-red-700">
+                            <ExclamationTriangleIcon className="h-5 w-5 flex-shrink-0" />
+                            <p>{errorMessage}</p>
+                          </div>
+                        )}
+
+                        {successMessage && (
+                          <div className="mt-4 rounded-md bg-green-50 p-3 text-sm text-green-700">
+                            {successMessage}
+                          </div>
+                        )}
+
+                        <div className="mt-6">
+                          {documentsQuery.isLoading ? (
+                            <p className="text-sm text-gray-500">Carregando documentos...</p>
+                          ) : documents.length === 0 ? (
+                            <p className="text-sm text-gray-500">
+                              Nenhum documento disponível para este agendamento.
+                            </p>
+                          ) : (
+                            <ul className="space-y-3">
+                              {documents.map((document) => (
+                                <li
+                                  key={document.id}
+                                  className="flex items-start justify-between rounded-lg border border-gray-200 bg-white p-4 shadow-sm"
+                                >
+                                  <div>
+                                    <p className="font-medium text-gray-900">
+                                      {document.original_file_name}
+                                      {document.status !== 'available' && (
+                                        <span className="ml-2 inline-flex items-center rounded-full bg-yellow-100 px-2 py-0.5 text-xs font-semibold text-yellow-800">
+                                          {document.status.replace('_', ' ')}
+                                        </span>
+                                      )}
+                                    </p>
+                                    <p className="text-sm text-gray-500">
+                                      {formatBytes(document.file_size)} • Upload em {formatDateTime(document.uploaded_at ?? document.created_at)}
+                                    </p>
+                                    {document.uploader_user_id && (
+                                      <p className="text-xs text-gray-400">
+                                        Enviado por: {document.uploader_user_id}
+                                        {document.source_ip ? ` • IP ${document.source_ip}` : ''}
+                                      </p>
+                                    )}
+                                  </div>
+                                  <div className="flex items-center space-x-2">
+                                    <button
+                                      type="button"
+                                      className="inline-flex items-center rounded-md border border-gray-200 bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50"
+                                      onClick={() => void handleDownload(document)}
+                                      disabled={workingDocumentId === document.id}
+                                    >
+                                      <ArrowDownTrayIcon className="h-4 w-4 mr-1" />
+                                      Download
+                                    </button>
+                                    <button
+                                      type="button"
+                                      className="inline-flex items-center rounded-md border border-red-200 bg-white px-3 py-2 text-sm font-medium text-red-600 shadow-sm hover:bg-red-50"
+                                      onClick={() => void handleDelete(document, false)}
+                                      disabled={workingDocumentId === document.id}
+                                    >
+                                      <TrashIcon className="h-4 w-4 mr-1" />
+                                      Excluir
+                                    </button>
+                                    {canHardDelete && (
+                                      <button
+                                        type="button"
+                                        className="inline-flex items-center rounded-md border border-red-300 bg-red-50 px-3 py-2 text-sm font-medium text-red-700 shadow-sm hover:bg-red-100"
+                                        onClick={() => void handleDelete(document, true)}
+                                        disabled={workingDocumentId === document.id}
+                                      >
+                                        <TrashIcon className="h-4 w-4 mr-1" />
+                                        Excluir definitivamente
+                                      </button>
+                                    )}
+                                  </div>
+                                </li>
+                              ))}
+                            </ul>
+                          )}
+                        </div>
+                      </section>
+                    </div>
+                  </div>
+                </Dialog.Panel>
+              </Transition.Child>
+            </div>
+          </div>
+        </div>
+      </Dialog>
+    </Transition>
+  );
+};
+
+export default AppointmentDetailDrawer;

--- a/frontend/src/components/AppointmentTable.tsx
+++ b/frontend/src/components/AppointmentTable.tsx
@@ -216,18 +216,36 @@ export const AppointmentTable: React.FC<AppointmentTableProps> = ({
         header: 'Ações',
         cell: ({ row }) => (
           <div className="flex space-x-2">
+            {onViewDetails && (
+              <button
+                onClick={() => onViewDetails(row.original)}
+                className="inline-flex items-center rounded-md border border-indigo-200 bg-indigo-50 px-2 py-1 text-xs font-medium text-indigo-700 hover:bg-indigo-100"
+                title="Ver documentos"
+              >
+                <DocumentTextIcon className="w-4 h-4 mr-1" />
+                Documentos
+              </button>
+            )}
             <button
               onClick={() => onDelete?.(row.original.id)}
-              className="p-1 text-red-600 hover:text-red-800 transition-colors"
+              className="inline-flex items-center rounded-md border border-red-200 bg-white px-2 py-1 text-xs font-medium text-red-600 hover:bg-red-50"
               title="Excluir agendamento"
             >
-              <TrashIcon className="w-4 h-4" />
+              <TrashIcon className="w-4 h-4 mr-1" />
+              Excluir
             </button>
           </div>
         ),
       },
     ],
-    [onStatusChange, onDriverChange, onCollectorChange, onDelete, drivers, collectors]
+    [
+      onStatusChange,
+      onDriverChange,
+      onCollectorChange,
+      onDelete,
+      drivers,
+      collectors,
+    ]
   );
 
   const table = useReactTable({

--- a/frontend/src/components/CalendarDayModal.tsx
+++ b/frontend/src/components/CalendarDayModal.tsx
@@ -20,6 +20,7 @@ export const CalendarDayModal: React.FC<DayModalProps> = ({
   onDelete,
   drivers = [],
   collectors = [],
+  onViewDetails,
 }) => {
   const dateString = formatCalendarDate(date, 'EEEE, dd \'de\' MMMM \'de\' yyyy');
   const hasAppointments = appointments.length > 0;
@@ -98,6 +99,7 @@ export const CalendarDayModal: React.FC<DayModalProps> = ({
                           onDriverChange={onDriverChange || (() => {})}
                           onCollectorChange={onCollectorChange || (() => {})}
                           onDelete={onDelete || (() => {})}
+                          onViewDetails={onViewDetails}
                           compact={true}
                         />
                       ))}

--- a/frontend/src/components/CollectorAgendaView.tsx
+++ b/frontend/src/components/CollectorAgendaView.tsx
@@ -21,6 +21,7 @@ interface CollectorAgendaViewProps {
   onAppointmentCollectorChange: (appointmentId: string, collectorId: string) => void;
   onAppointmentDelete: (id: string) => void;
   onDateChange?: (date: Date) => void;
+  onAppointmentViewDetails?: (appointment: Appointment) => void;
 }
 
 interface CollectorAppointments {
@@ -51,6 +52,7 @@ export const CollectorAgendaView: React.FC<CollectorAgendaViewProps> = ({
   onAppointmentCollectorChange,
   onAppointmentDelete,
   onDateChange,
+  onAppointmentViewDetails,
 }) => {
   const selectedDateStr = useMemo(() => {
     return selectedDate.toISOString().split('T')[0];
@@ -383,6 +385,7 @@ export const CollectorAgendaView: React.FC<CollectorAgendaViewProps> = ({
                   onDriverChange={onAppointmentDriverChange}
                   onCollectorChange={onAppointmentCollectorChange}
                   onDelete={onAppointmentDelete}
+                  onViewDetails={onAppointmentViewDetails}
                   compact={true}
                 />
               ))}

--- a/frontend/src/pages/AppointmentsPage.tsx
+++ b/frontend/src/pages/AppointmentsPage.tsx
@@ -5,6 +5,7 @@ import {
 } from '@heroicons/react/24/outline';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import React, { useState } from 'react';
+import AppointmentDetailDrawer from '../components/AppointmentDetailDrawer';
 import { AppointmentCardList } from '../components/AppointmentCardList';
 import { AppointmentCalendarView } from '../components/AppointmentCalendarView';
 import { AppointmentFilters } from '../components/AppointmentFilters';
@@ -12,7 +13,7 @@ import { CollectorAgendaView } from '../components/CollectorAgendaView';
 import { FileUpload } from '../components/FileUpload';
 import { ViewModeToggle, type ViewMode } from '../components/ViewModeToggle';
 import { appointmentAPI, collectorAPI, driverAPI } from '../services/api';
-import type { AppointmentFilter, ExcelUploadResponse } from '../types/appointment';
+import type { Appointment, AppointmentFilter, ExcelUploadResponse } from '../types/appointment';
 
 export const AppointmentsPage: React.FC = () => {
   const queryClient = useQueryClient();
@@ -27,6 +28,8 @@ export const AppointmentsPage: React.FC = () => {
   const [currentCalendarDate, setCurrentCalendarDate] = useState<Date>(new Date());
   const [selectedDate, setSelectedDate] = useState<Date | undefined>(undefined);
   const [selectedAgendaDate, setSelectedAgendaDate] = useState<Date>(new Date());
+  const [selectedAppointment, setSelectedAppointment] = useState<Appointment | null>(null);
+  const [isDetailOpen, setIsDetailOpen] = useState(false);
 
   // Fetch appointments
   const { 
@@ -134,6 +137,16 @@ export const AppointmentsPage: React.FC = () => {
     } catch (error) {
       console.error('Error updating appointment collector:', error);
     }
+  };
+
+  const handleViewDocuments = (appointment: Appointment) => {
+    setSelectedAppointment(appointment);
+    setIsDetailOpen(true);
+  };
+
+  const handleCloseDetails = () => {
+    setIsDetailOpen(false);
+    setSelectedAppointment(null);
   };
 
   return (
@@ -262,6 +275,7 @@ export const AppointmentsPage: React.FC = () => {
               onDriverChange={handleDriverChange}
               onCollectorChange={handleCollectorChange}
               onDelete={handleDelete}
+              onViewDetails={handleViewDocuments}
             />
           )}
 
@@ -276,6 +290,7 @@ export const AppointmentsPage: React.FC = () => {
               onAppointmentDriverChange={handleDriverChange}
               onAppointmentCollectorChange={handleCollectorChange}
               onAppointmentDelete={handleDelete}
+              onAppointmentViewDetails={handleViewDocuments}
               drivers={driversData?.drivers || []}
               collectors={collectorsData?.collectors || []}
               isLoading={isLoadingAppointments}
@@ -311,6 +326,7 @@ export const AppointmentsPage: React.FC = () => {
                 onAppointmentCollectorChange={handleCollectorChange}
                 onAppointmentDelete={handleDelete}
                 onDateChange={setSelectedAgendaDate}
+                onAppointmentViewDetails={handleViewDocuments}
               />
             </div>
           )}
@@ -343,6 +359,12 @@ export const AppointmentsPage: React.FC = () => {
           )}
         </div>
       </div>
+
+      <AppointmentDetailDrawer
+        appointment={selectedAppointment}
+        isOpen={isDetailOpen}
+        onClose={handleCloseDetails}
+      />
     </div>
   );
 };

--- a/frontend/src/types/agenda.ts
+++ b/frontend/src/types/agenda.ts
@@ -30,6 +30,7 @@ export interface CalendarViewProps {
   onAppointmentDriverChange?: (appointmentId: string, driverId: string) => void;
   onAppointmentCollectorChange?: (appointmentId: string, collectorId: string) => void;
   onAppointmentDelete?: (id: string) => void;
+  onAppointmentViewDetails?: (appointment: Appointment) => void;
   drivers?: Array<{ id: string; nome_completo: string; cnh?: string; telefone?: string }>;
   collectors?: Array<{ id: string; nome_completo: string; cpf?: string; telefone?: string }>;
   isLoading?: boolean;
@@ -44,6 +45,7 @@ export interface DayModalProps {
   onDriverChange?: (appointmentId: string, driverId: string) => void;
   onCollectorChange?: (appointmentId: string, collectorId: string) => void;
   onDelete?: (id: string) => void;
+  onViewDetails?: (appointment: Appointment) => void;
   drivers?: Array<{ id: string; nome_completo: string; cnh?: string; telefone?: string }>;
   collectors?: Array<{ id: string; nome_completo: string; cpf?: string; telefone?: string }>;
 }

--- a/frontend/src/types/patientDocument.ts
+++ b/frontend/src/types/patientDocument.ts
@@ -1,0 +1,60 @@
+export type DocumentStatus =
+  | 'pending'
+  | 'available'
+  | 'soft_deleted'
+  | 'hard_deleted';
+
+export interface PatientDocument {
+  id: string;
+  appointment_id: string;
+  patient_id: string;
+  original_file_name: string;
+  sanitized_file_name: string;
+  content_type: string;
+  file_size: number;
+  status: DocumentStatus;
+  storage_key: string;
+  uploader_user_id?: string | null;
+  source_ip?: string | null;
+  created_at: string;
+  uploaded_at?: string | null;
+  deleted_at?: string | null;
+  deleted_by?: string | null;
+  etag?: string | null;
+}
+
+export interface PatientDocumentList {
+  documents: PatientDocument[];
+}
+
+export interface DownloadUrlPayload {
+  url: string;
+  expires_in: number;
+}
+
+export interface PresignUploadResponse {
+  document_id: string;
+  upload_url: string;
+  headers: Record<string, string>;
+  expires_in: number;
+  storage_key: string;
+}
+
+export interface ConfirmUploadRequest {
+  file_size: number;
+  etag?: string | null;
+}
+
+export interface PresignUploadRequest {
+  patient_id: string;
+  file_name: string;
+  content_type: string;
+  file_size: number;
+}
+
+export interface ApiDataResponse<T> {
+  success: boolean;
+  message?: string;
+  data: T;
+  request_id?: string;
+}


### PR DESCRIPTION
## Summary
- add Mongo-backed patient document metadata with R2 client, service logic, and FastAPI endpoints for presign, confirm, list, download, and delete flows
- wire a new appointment document drawer on the frontend with drag-and-drop uploads, list actions, and shared access from cards, calendar, and agenda views
- document the rollout plan, environment variables, and validation checklist for Cloudflare R2/MinIO in docs/features/docs/patient-docs-r2.md while updating env examples

## Testing
- `npm run lint` *(fails: legacy @typescript-eslint errors in existing files)*

## Manual Validation
- [ ] Upload PDF/JPG ≤10MB via UI stores metadata and file in MinIO/R2
- [ ] Invalid MIME upload is rejected with 400 response
- [ ] Download link expires after ~10 minutes
- [ ] Soft delete hides document without removing blob
- [ ] Hard delete (admin) removes object from storage and denies collaborator role

------
https://chatgpt.com/codex/tasks/task_e_68d6b92ec2ac8323bed2b531a4128786