### PR TITLE
feat: add client management flow with CPF sync

### DIFF
--- a/backend/src/application/dtos/__init__.py
+++ b/backend/src/application/dtos/__init__.py
@@ -11,6 +11,14 @@ from .appointment_dto import (
     DashboardStatsDTO,
     ExcelUploadResponseDTO,
 )
+from .client_dto import (
+    ClientCreateDTO,
+    ClientDetailResponseDTO,
+    ClientListResponseDTO,
+    ClientResponseDTO,
+    ClientSummaryDTO,
+    ClientUpdateDTO,
+)
 from .tag_dto import (
     TagCreateDTO,
     TagListResponseDTO,
@@ -27,6 +35,12 @@ __all__ = [
     "AppointmentScope",
     "ExcelUploadResponseDTO",
     "DashboardStatsDTO",
+    "ClientCreateDTO",
+    "ClientUpdateDTO",
+    "ClientResponseDTO",
+    "ClientDetailResponseDTO",
+    "ClientListResponseDTO",
+    "ClientSummaryDTO",
     "TagCreateDTO",
     "TagUpdateDTO",
     "TagResponseDTO",

--- a/backend/src/application/dtos/appointment_dto.py
+++ b/backend/src/application/dtos/appointment_dto.py
@@ -5,9 +5,10 @@ from enum import Enum
 from typing import Dict, List, Literal, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from src.application.dtos.tag_dto import TagSummaryDTO
+from src.domain.utils import normalize_cpf
 
 
 class AppointmentScope(str, Enum):
@@ -36,6 +37,7 @@ class AppointmentCreateDTO(BaseModel):
     )
     status: str = Field("Pendente", description="Status do Agendamento")
     telefone: Optional[str] = Field(None, description="Telefone do Paciente")
+    cpf: str = Field(..., description="CPF do Paciente (apenas dígitos)")
     carro: Optional[str] = Field(
         None, description="Informações do carro utilizado"
     )
@@ -58,6 +60,14 @@ class AppointmentCreateDTO(BaseModel):
         default_factory=list,
         description="Lista de IDs de tags associadas ao agendamento",
     )
+
+    @field_validator("cpf", mode="before")
+    @classmethod
+    def normalize_cpf_value(cls, value: str) -> str:
+        normalized = normalize_cpf(value)
+        if not normalized or len(normalized) != 11:
+            raise ValueError("CPF inválido. Informe 11 dígitos válidos.")
+        return normalized
 
 
 class AppointmentUpdateDTO(BaseModel):

--- a/backend/src/application/dtos/client_dto.py
+++ b/backend/src/application/dtos/client_dto.py
@@ -1,0 +1,152 @@
+"""DTOs para operações envolvendo clientes."""
+
+from datetime import datetime
+from typing import List, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field, field_validator
+
+from src.domain.utils import normalize_cpf
+
+
+class ClientCreateDTO(BaseModel):
+    """Dados para criação de um novo cliente."""
+
+    nome: str = Field(..., description="Nome completo do cliente")
+    cpf: str = Field(..., description="CPF do cliente (somente dígitos)")
+    telefone: Optional[str] = Field(
+        None, description="Telefone do cliente (somente dígitos)"
+    )
+    email: Optional[str] = Field(None, description="Email do cliente")
+    observacoes: Optional[str] = Field(None, description="Observações internas")
+
+    @field_validator("cpf", mode="before")
+    @classmethod
+    def normalize_cpf_value(cls, value: str) -> str:
+        normalized = normalize_cpf(value)
+        if not normalized or len(normalized) != 11:
+            raise ValueError("CPF inválido. Informe 11 dígitos válidos.")
+        return normalized
+
+    @field_validator("nome")
+    @classmethod
+    def validate_nome(cls, value: str) -> str:
+        if not value or not value.strip():
+            raise ValueError("Nome é obrigatório")
+        return value.strip()
+
+    @field_validator("telefone", mode="before")
+    @classmethod
+    def normalize_phone(cls, value: Optional[str]) -> Optional[str]:
+        if not value:
+            return None
+        digits = "".join(filter(str.isdigit, str(value)))
+        if digits and len(digits) not in (10, 11):
+            raise ValueError("Telefone deve conter 10 ou 11 dígitos")
+        return digits if digits else None
+
+
+class ClientUpdateDTO(BaseModel):
+    """Dados para atualização parcial de um cliente."""
+
+    nome: Optional[str] = Field(None, description="Nome completo do cliente")
+    telefone: Optional[str] = Field(
+        None, description="Telefone do cliente (somente dígitos)"
+    )
+    email: Optional[str] = Field(None, description="Email do cliente")
+    observacoes: Optional[str] = Field(None, description="Observações internas")
+
+    @field_validator("nome")
+    @classmethod
+    def validate_nome(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        trimmed = value.strip()
+        if not trimmed:
+            raise ValueError("Nome não pode ser vazio")
+        return trimmed
+
+    @field_validator("telefone", mode="before")
+    @classmethod
+    def normalize_phone(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        digits = "".join(filter(str.isdigit, str(value)))
+        if digits and len(digits) not in (10, 11):
+            raise ValueError("Telefone deve conter 10 ou 11 dígitos")
+        return digits if digits else None
+
+
+class ClientHistoryEntryDTO(BaseModel):
+    """Representação de uma entrada no histórico de agendamentos."""
+
+    appointment_id: str
+    data_agendamento: Optional[datetime] = None
+    hora_agendamento: Optional[str] = None
+    status: Optional[str] = None
+    nome_unidade: Optional[str] = None
+    nome_marca: Optional[str] = None
+    created_at: datetime
+
+
+class ClientResponseDTO(BaseModel):
+    """Representação completa de um cliente."""
+
+    id: UUID
+    nome: str
+    cpf: str
+    telefone: Optional[str] = None
+    email: Optional[str] = None
+    observacoes: Optional[str] = None
+    total_agendamentos: int
+    ultimo_agendamento_em: Optional[datetime] = None
+    ultimo_status: Optional[str] = None
+    ultima_unidade: Optional[str] = None
+    ultima_marca: Optional[str] = None
+    historico_agendamentos: List[ClientHistoryEntryDTO]
+    created_at: datetime
+    updated_at: Optional[datetime] = None
+
+
+class ClientSummaryDTO(BaseModel):
+    """Resumo para listagem de clientes."""
+
+    id: UUID
+    nome: str
+    cpf: str
+    telefone: Optional[str] = None
+    email: Optional[str] = None
+    observacoes: Optional[str] = None
+    total_agendamentos: int
+    ultimo_agendamento_em: Optional[datetime] = None
+    ultimo_status: Optional[str] = None
+    ultima_unidade: Optional[str] = None
+    ultima_marca: Optional[str] = None
+    created_at: datetime
+    updated_at: Optional[datetime] = None
+
+
+class ClientPaginationDTO(BaseModel):
+    page: int
+    page_size: int
+    total_items: int
+    total_pages: int
+    has_next: bool
+    has_previous: bool
+
+
+class ClientListResponseDTO(BaseModel):
+    """Resposta paginada para listagem de clientes."""
+
+    success: bool
+    message: Optional[str] = None
+    clients: List[ClientSummaryDTO]
+    pagination: ClientPaginationDTO
+
+
+class ClientDetailResponseDTO(BaseModel):
+    """Resposta detalhada com histórico completo."""
+
+    success: bool
+    message: Optional[str] = None
+    client: Optional[ClientResponseDTO] = None

--- a/backend/src/application/services/__init__.py
+++ b/backend/src/application/services/__init__.py
@@ -3,7 +3,8 @@ Application services.
 """
 
 from .appointment_service import AppointmentService
+from .client_service import ClientService
 from .excel_parser_service import ExcelParserService
 from .tag_service import TagService
 
-__all__ = ["ExcelParserService", "AppointmentService", "TagService"]
+__all__ = ["ExcelParserService", "AppointmentService", "ClientService", "TagService"]

--- a/backend/src/application/services/client_service.py
+++ b/backend/src/application/services/client_service.py
@@ -1,0 +1,197 @@
+"""Serviços de aplicação relacionados a clientes."""
+
+from math import ceil
+from typing import Dict, List, Optional
+
+from src.application.dtos.client_dto import (
+    ClientCreateDTO,
+    ClientDetailResponseDTO,
+    ClientListResponseDTO,
+    ClientResponseDTO,
+    ClientSummaryDTO,
+    ClientUpdateDTO,
+)
+from src.domain.entities.appointment import Appointment
+from src.domain.entities.client import Client, ClientAppointmentHistoryEntry
+from src.domain.repositories.client_repository_interface import (
+    ClientRepositoryInterface,
+)
+
+
+class ClientService:
+    """Orquestra regras de negócio para o gerenciamento de clientes."""
+
+    def __init__(self, repository: ClientRepositoryInterface) -> None:
+        self.repository = repository
+
+    async def list_clients(
+        self, search: Optional[str] = None, page: int = 1, page_size: int = 50
+    ) -> ClientListResponseDTO:
+        """List clients with optional search and pagination."""
+
+        if page < 1:
+            page = 1
+        if page_size < 1:
+            page_size = 1
+
+        skip = (page - 1) * page_size
+        clients, total = await self.repository.list_clients(
+            search=search, skip=skip, limit=page_size
+        )
+
+        total_pages = ceil(total / page_size) if page_size else 1
+        pagination = {
+            "page": page,
+            "page_size": page_size,
+            "total_items": total,
+            "total_pages": max(total_pages, 1),
+            "has_next": page * page_size < total,
+            "has_previous": page > 1,
+        }
+
+        summaries = [
+            ClientSummaryDTO(**client.model_dump()) for client in clients
+        ]
+
+        return ClientListResponseDTO(
+            success=True,
+            clients=summaries,
+            pagination=pagination,
+        )
+
+    async def create_client(self, data: ClientCreateDTO) -> Dict:
+        """Register a new client if CPF is not already in use."""
+
+        existing = await self.repository.find_by_cpf(data.cpf)
+        if existing:
+            return {
+                "success": False,
+                "message": "CPF já cadastrado para outro cliente.",
+                "error_code": "duplicate",
+            }
+
+        client = Client(
+            nome=data.nome,
+            cpf=data.cpf,
+            telefone=data.telefone,
+            email=data.email,
+            observacoes=data.observacoes,
+        )
+
+        created = await self.repository.create(client)
+        return {
+            "success": True,
+            "message": "Cliente cadastrado com sucesso.",
+            "client": ClientResponseDTO(**created.model_dump()),
+        }
+
+    async def update_client(self, client_id: str, data: ClientUpdateDTO) -> Dict:
+        """Update existing client fields."""
+
+        client = await self.repository.find_by_id(client_id)
+        if not client:
+            return {
+                "success": False,
+                "message": "Cliente não encontrado.",
+                "error_code": "not_found",
+            }
+
+        if data.nome is not None:
+            client.nome = data.nome
+        if data.telefone is not None:
+            client.telefone = data.telefone
+        if data.email is not None:
+            client.email = data.email
+        if data.observacoes is not None:
+            client.observacoes = data.observacoes
+
+        client.mark_as_updated()
+        updated = await self.repository.update(client)
+        return {
+            "success": True,
+            "message": "Cliente atualizado com sucesso.",
+            "client": ClientResponseDTO(**updated.model_dump()),
+        }
+
+    async def get_client_detail(self, client_id: str) -> ClientDetailResponseDTO:
+        """Fetch detailed information for a client."""
+
+        client = await self.repository.find_by_id(client_id)
+        if not client:
+            return ClientDetailResponseDTO(
+                success=False,
+                message="Cliente não encontrado.",
+                client=None,  # type: ignore[arg-type]
+            )
+
+        return ClientDetailResponseDTO(
+            success=True,
+            client=ClientResponseDTO(**client.model_dump()),
+        )
+
+    async def sync_from_appointment(self, appointment: Appointment) -> None:
+        """Create or update client data based on an appointment."""
+
+        if not appointment.cpf:
+            return
+
+        existing = await self.repository.find_by_cpf(appointment.cpf)
+        history_entry = ClientAppointmentHistoryEntry(
+            appointment_id=str(appointment.id),
+            data_agendamento=appointment.data_agendamento,
+            hora_agendamento=appointment.hora_agendamento,
+            status=appointment.status,
+            nome_unidade=appointment.nome_unidade,
+            nome_marca=appointment.nome_marca,
+            created_at=appointment.created_at,
+        )
+
+        if existing:
+            updated_history = False
+            for entry in existing.historico_agendamentos:
+                if entry.appointment_id == history_entry.appointment_id:
+                    entry.data_agendamento = history_entry.data_agendamento
+                    entry.hora_agendamento = history_entry.hora_agendamento
+                    entry.status = history_entry.status
+                    entry.nome_unidade = history_entry.nome_unidade
+                    entry.nome_marca = history_entry.nome_marca
+                    updated_history = True
+                    break
+
+            if not updated_history:
+                existing.historico_agendamentos.append(history_entry)
+                existing.total_agendamentos += 1
+
+            existing.nome = appointment.nome_paciente
+            if appointment.telefone:
+                existing.telefone = appointment.telefone
+            existing.ultimo_agendamento_em = (
+                appointment.data_agendamento or existing.ultimo_agendamento_em
+            )
+            existing.ultimo_status = appointment.status or existing.ultimo_status
+            existing.ultima_unidade = (
+                appointment.nome_unidade or existing.ultima_unidade
+            )
+            existing.ultima_marca = appointment.nome_marca or existing.ultima_marca
+            existing.mark_as_updated()
+            await self.repository.update(existing)
+            return
+
+        client = Client(
+            nome=appointment.nome_paciente,
+            cpf=appointment.cpf,
+            telefone=appointment.telefone,
+            total_agendamentos=1,
+            ultimo_agendamento_em=appointment.data_agendamento,
+            ultimo_status=appointment.status,
+            ultima_unidade=appointment.nome_unidade,
+            ultima_marca=appointment.nome_marca,
+            historico_agendamentos=[history_entry],
+        )
+        await self.repository.create(client)
+
+    async def sync_from_appointments(self, appointments: List[Appointment]) -> None:
+        """Sync clients for a batch of appointments."""
+
+        for appointment in appointments:
+            await self.sync_from_appointment(appointment)

--- a/backend/src/domain/entities/__init__.py
+++ b/backend/src/domain/entities/__init__.py
@@ -4,8 +4,18 @@ Domain entities module.
 
 from .appointment import Appointment
 from .car import Car
+from .client import Client, ClientAppointmentHistoryEntry
 from .collector import Collector
 from .driver import Driver
 from .tag import Tag, TagReference
 
-__all__ = ["Appointment", "Car", "Collector", "Driver", "Tag", "TagReference"]
+__all__ = [
+    "Appointment",
+    "Car",
+    "Client",
+    "ClientAppointmentHistoryEntry",
+    "Collector",
+    "Driver",
+    "Tag",
+    "TagReference",
+]

--- a/backend/src/domain/entities/client.py
+++ b/backend/src/domain/entities/client.py
@@ -1,0 +1,87 @@
+"""Domain entities for client management."""
+
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import Field, field_validator
+
+from src.domain.base import Entity, ValueObject
+from src.domain.utils import normalize_cpf
+
+
+class ClientAppointmentHistoryEntry(ValueObject):
+    """Snapshot of an appointment associated with a client."""
+
+    appointment_id: str = Field(..., description="Identificador do agendamento")
+    data_agendamento: Optional[datetime] = Field(
+        None, description="Data do agendamento"
+    )
+    hora_agendamento: Optional[str] = Field(
+        None, description="Hora do agendamento (HH:MM)"
+    )
+    status: Optional[str] = Field(None, description="Status atual do agendamento")
+    nome_unidade: Optional[str] = Field(None, description="Unidade do agendamento")
+    nome_marca: Optional[str] = Field(None, description="Marca/Clínica do agendamento")
+    created_at: datetime = Field(
+        default_factory=datetime.utcnow,
+        description="Momento em que o vínculo com o cliente foi registrado",
+    )
+
+
+class Client(Entity):
+    """Client aggregate with contact information and appointment history."""
+
+    nome: str = Field(..., description="Nome completo do cliente")
+    cpf: str = Field(..., description="CPF do cliente apenas com dígitos")
+    telefone: Optional[str] = Field(
+        None, description="Telefone principal do cliente (apenas dígitos)"
+    )
+    email: Optional[str] = Field(None, description="Email do cliente")
+    observacoes: Optional[str] = Field(None, description="Observações internas")
+    total_agendamentos: int = Field(
+        0, description="Quantidade total de agendamentos vinculados ao cliente"
+    )
+    ultimo_agendamento_em: Optional[datetime] = Field(
+        None, description="Data do último agendamento"
+    )
+    ultimo_status: Optional[str] = Field(
+        None, description="Status do último agendamento registrado"
+    )
+    ultima_unidade: Optional[str] = Field(
+        None, description="Unidade do último agendamento"
+    )
+    ultima_marca: Optional[str] = Field(
+        None, description="Marca do último agendamento"
+    )
+    historico_agendamentos: List[ClientAppointmentHistoryEntry] = Field(
+        default_factory=list,
+        description="Histórico completo de agendamentos associados ao cliente",
+    )
+
+    @field_validator("cpf", mode="before")
+    @classmethod
+    def normalize_cpf_value(cls, value: str) -> str:
+        """Ensure CPF is stored with digits only."""
+        normalized = normalize_cpf(value)
+        if not normalized or len(normalized) != 11:
+            raise ValueError("CPF inválido. Informe 11 dígitos válidos.")
+        return normalized
+
+    @field_validator("nome")
+    @classmethod
+    def validate_nome(cls, value: str) -> str:
+        """Trim and validate client name."""
+        if not value or not value.strip():
+            raise ValueError("Nome do cliente é obrigatório")
+        return value.strip()
+
+    @field_validator("telefone", mode="before")
+    @classmethod
+    def normalize_phone(cls, value: Optional[str]) -> Optional[str]:
+        """Normalize phone numbers keeping only digits."""
+        if not value:
+            return None
+        digits = "".join(filter(str.isdigit, str(value)))
+        if digits and len(digits) not in (10, 11):
+            raise ValueError("Telefone deve conter 10 ou 11 dígitos")
+        return digits if digits else None

--- a/backend/src/domain/repositories/__init__.py
+++ b/backend/src/domain/repositories/__init__.py
@@ -4,6 +4,7 @@ Domain repository interfaces.
 
 from .appointment_repository_interface import AppointmentRepositoryInterface
 from .car_repository_interface import CarRepositoryInterface
+from .client_repository_interface import ClientRepositoryInterface
 from .collector_repository_interface import CollectorRepositoryInterface
 from .driver_repository_interface import DriverRepositoryInterface
 from .tag_repository_interface import TagRepositoryInterface
@@ -11,6 +12,7 @@ from .tag_repository_interface import TagRepositoryInterface
 __all__ = [
     "AppointmentRepositoryInterface",
     "CarRepositoryInterface",
+    "ClientRepositoryInterface",
     "CollectorRepositoryInterface",
     "DriverRepositoryInterface",
     "TagRepositoryInterface",

--- a/backend/src/domain/repositories/client_repository_interface.py
+++ b/backend/src/domain/repositories/client_repository_interface.py
@@ -1,0 +1,45 @@
+"""Interface para repositórios de clientes."""
+
+from abc import ABC, abstractmethod
+from typing import List, Optional, Tuple
+
+from src.domain.entities.client import Client, ClientAppointmentHistoryEntry
+
+
+class ClientRepositoryInterface(ABC):
+    """Contrato para persistência de clientes."""
+
+    @abstractmethod
+    async def create(self, client: Client) -> Client:
+        """Persist a new client entity."""
+
+    @abstractmethod
+    async def update(self, client: Client) -> Client:
+        """Update an existing client entity."""
+
+    @abstractmethod
+    async def find_by_id(self, client_id: str) -> Optional[Client]:
+        """Retrieve a client by identifier."""
+
+    @abstractmethod
+    async def find_by_cpf(self, cpf: str) -> Optional[Client]:
+        """Retrieve a client using CPF as unique key."""
+
+    @abstractmethod
+    async def list_clients(
+        self,
+        search: Optional[str] = None,
+        skip: int = 0,
+        limit: int = 50,
+    ) -> Tuple[List[Client], int]:
+        """List clients applying optional search and pagination."""
+
+    @abstractmethod
+    async def ensure_indexes(self) -> None:
+        """Ensure database indexes for the collection exist."""
+
+    @abstractmethod
+    async def append_history_entry(
+        self, client_id: str, entry: ClientAppointmentHistoryEntry
+    ) -> None:
+        """Append a history entry without duplications."""

--- a/backend/src/infrastructure/container.py
+++ b/backend/src/infrastructure/container.py
@@ -9,6 +9,7 @@ from src.infrastructure.repositories.appointment_repository import (
     AppointmentRepository,
 )
 from src.infrastructure.repositories.car_repository import CarRepository
+from src.infrastructure.repositories.client_repository import ClientRepository
 from src.infrastructure.repositories.collector_repository import (
     CollectorRepository,
 )
@@ -42,6 +43,7 @@ class Container:
         self._car_repository: Optional[CarRepository] = None
         self._driver_repository: Optional[DriverRepository] = None
         self._collector_repository: Optional[CollectorRepository] = None
+        self._client_repository: Optional[ClientRepository] = None
         self._user_repository: Optional[UserRepository] = None
         self._notification_repository: Optional[NotificationRepository] = None
         self._tag_repository: Optional[TagRepository] = None
@@ -142,6 +144,14 @@ class Container:
         return self._collector_repository
 
     @property
+    def client_repository(self) -> ClientRepository:
+        """Get client repository instance."""
+
+        if self._client_repository is None:
+            self._client_repository = ClientRepository(self.database)
+        return self._client_repository
+
+    @property
     def logistics_package_repository(self) -> LogisticsPackageRepository:
         """Get logistics package repository instance."""
 
@@ -227,6 +237,7 @@ class Container:
             await self.car_repository.create_indexes()
             await self.driver_repository.create_indexes()
             await self.collector_repository.create_indexes()
+            await self.client_repository.ensure_indexes()
             await self.user_repository.ensure_indexes()
             await self.notification_repository.create_indexes()
             await self.tag_repository.ensure_indexes()
@@ -316,6 +327,12 @@ async def get_collector_repository() -> CollectorRepository:
         CollectorRepository: Repository instance
     """
     return container.collector_repository
+
+
+async def get_client_repository() -> ClientRepository:
+    """Dependency for getting client repository instance."""
+
+    return container.client_repository
 
 
 async def get_user_repository() -> UserRepository:

--- a/backend/src/infrastructure/repositories/__init__.py
+++ b/backend/src/infrastructure/repositories/__init__.py
@@ -3,6 +3,7 @@ Infrastructure repository implementations.
 """
 
 from .appointment_repository import AppointmentRepository
+from .client_repository import ClientRepository
 from .tag_repository import TagRepository
 
-__all__ = ["AppointmentRepository", "TagRepository"]
+__all__ = ["AppointmentRepository", "ClientRepository", "TagRepository"]

--- a/backend/src/infrastructure/repositories/appointment_repository.py
+++ b/backend/src/infrastructure/repositories/appointment_repository.py
@@ -4,7 +4,7 @@ MongoDB implementation of AppointmentRepository.
 
 import asyncio
 from copy import deepcopy
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Tuple
 from uuid import UUID
 
@@ -635,6 +635,21 @@ class AppointmentRepository(AppointmentRepositoryInterface):
             {"date": item["_id"], "value": int(item["count"])}
             for item in trend_result
         ]
+
+        if start_date and end_date:
+            total_days = (end_date - start_date).days
+            if total_days > 0:
+                trend_index = {point["date"]: point["value"] for point in trend_points}
+                trend_points = [
+                    {
+                        "date": (start_date + timedelta(days=offset)).strftime("%Y-%m-%d"),
+                        "value": trend_index.get(
+                            (start_date + timedelta(days=offset)).strftime("%Y-%m-%d"),
+                            0,
+                        ),
+                    }
+                    for offset in range(total_days)
+                ]
 
         top_units = [
             {

--- a/backend/src/infrastructure/repositories/client_repository.py
+++ b/backend/src/infrastructure/repositories/client_repository.py
@@ -1,0 +1,108 @@
+"""MongoDB implementation for client repository."""
+
+import re
+from typing import List, Optional, Tuple
+
+from motor.motor_asyncio import AsyncIOMotorDatabase
+from pymongo import ASCENDING, DESCENDING
+
+from src.domain.entities.client import Client, ClientAppointmentHistoryEntry
+from src.domain.repositories.client_repository_interface import (
+    ClientRepositoryInterface,
+)
+
+
+class ClientRepository(ClientRepositoryInterface):
+    """Persistência de clientes usando MongoDB."""
+
+    def __init__(self, database: AsyncIOMotorDatabase) -> None:
+        self.database = database
+        self.collection = database.clients
+
+    async def ensure_indexes(self) -> None:
+        await self.collection.create_index("cpf", unique=True)
+        await self.collection.create_index([("nome", ASCENDING)])
+        await self.collection.create_index(
+            [("ultimo_agendamento_em", DESCENDING)], name="idx_last_appointment"
+        )
+
+    async def create(self, client: Client) -> Client:
+        data = self._to_document(client)
+        await self.collection.insert_one(data)
+        return client
+
+    async def update(self, client: Client) -> Client:
+        data = self._to_document(client)
+        await self.collection.update_one({"id": data["id"]}, {"$set": data})
+        return client
+
+    async def find_by_id(self, client_id: str) -> Optional[Client]:
+        doc = await self.collection.find_one({"id": client_id})
+        if not doc:
+            return None
+        return self._from_document(doc)
+
+    async def find_by_cpf(self, cpf: str) -> Optional[Client]:
+        doc = await self.collection.find_one({"cpf": cpf})
+        if not doc:
+            return None
+        return self._from_document(doc)
+
+    async def list_clients(
+        self, search: Optional[str] = None, skip: int = 0, limit: int = 50
+    ) -> Tuple[List[Client], int]:
+        query: dict = {}
+        if search:
+            text = search.strip()
+            digits = re.sub(r"\D", "", text)
+            or_filters = []
+            if text:
+                or_filters.append({"nome": {"$regex": re.escape(text), "$options": "i"}})
+            if digits:
+                or_filters.append({"cpf": {"$regex": digits}})
+            if or_filters:
+                query = {"$or": or_filters}
+
+        cursor = (
+            self.collection.find(query)
+            .sort("ultimo_agendamento_em", DESCENDING)
+            .skip(skip)
+            .limit(limit)
+        )
+        items: List[Client] = []
+        async for doc in cursor:
+            items.append(self._from_document(doc))
+
+        total = await self.collection.count_documents(query)
+        return items, total
+
+    async def append_history_entry(
+        self, client_id: str, entry: ClientAppointmentHistoryEntry
+    ) -> None:
+        await self.collection.update_one(
+            {"id": client_id, "historico_agendamentos.appointment_id": {"$ne": entry.appointment_id}},
+            {
+                "$push": {
+                    "historico_agendamentos": entry.model_dump(),
+                },
+                "$inc": {"total_agendamentos": 1},
+            },
+        )
+
+    def _to_document(self, client: Client) -> dict:
+        data = client.model_dump()
+        data["id"] = str(data["id"])
+        data["historico_agendamentos"] = [
+            entry.model_dump() for entry in client.historico_agendamentos
+        ]
+        return data
+
+    def _from_document(self, doc: dict) -> Client:
+        document = dict(doc)
+        document.pop("_id", None)
+        history = [
+            ClientAppointmentHistoryEntry(**entry)
+            for entry in document.get("historico_agendamentos", [])
+        ]
+        document["historico_agendamentos"] = history
+        return Client(**document)

--- a/backend/src/presentation/api/v1/endpoints/appointments.py
+++ b/backend/src/presentation/api/v1/endpoints/appointments.py
@@ -32,6 +32,7 @@ from src.application.services.address_normalization_service import (
     AddressNormalizationService,
 )
 from src.application.services.appointment_service import AppointmentService
+from src.application.services.client_service import ClientService
 from src.application.services.car_service import CarService
 from src.application.services.dashboard_analytics_service import (
     DashboardAnalyticsService,
@@ -45,12 +46,14 @@ from src.infrastructure.config import Settings, get_settings
 from src.infrastructure.container import (
     get_appointment_repository,
     get_car_repository,
+    get_client_repository,
     get_logistics_package_repository,
     get_tag_repository,
 )
 from src.infrastructure.repositories.appointment_repository import (
     AppointmentRepository,
 )
+from src.infrastructure.repositories.client_repository import ClientRepository
 from src.presentation.dependencies.auth import (
     get_current_active_user,
     get_current_admin_user,
@@ -74,6 +77,7 @@ async def get_appointment_service(
     car_repository=Depends(get_car_repository),
     logistics_package_repository=Depends(get_logistics_package_repository),
     tag_repository: TagRepository = Depends(get_tag_repository),
+    client_repository: ClientRepository = Depends(get_client_repository),
     settings: Settings = Depends(get_settings),
 ) -> AppointmentService:
     """Get appointment service instance."""
@@ -100,12 +104,15 @@ async def get_appointment_service(
     except ValueError:
         # OpenRouter not configured, continue without normalization services
         excel_parser = ExcelParserService(car_service=car_service)
+    client_service = ClientService(client_repository)
+
     return AppointmentService(
         appointment_repository,
         excel_parser,
         logistics_package_repository=logistics_package_repository,
         tag_repository=tag_repository,
         max_tags_per_appointment=settings.max_tags_per_appointment,
+        client_service=client_service,
     )
 
 

--- a/backend/src/presentation/api/v1/endpoints/clients.py
+++ b/backend/src/presentation/api/v1/endpoints/clients.py
@@ -1,0 +1,114 @@
+"""Client management API endpoints."""
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from src.application.dtos.client_dto import (
+    ClientCreateDTO,
+    ClientDetailResponseDTO,
+    ClientListResponseDTO,
+    ClientResponseDTO,
+    ClientUpdateDTO,
+)
+from src.application.services.client_service import ClientService
+from src.infrastructure.container import get_client_repository
+from src.infrastructure.repositories.client_repository import ClientRepository
+from src.presentation.api.responses import DataResponse
+
+router = APIRouter()
+
+
+async def get_client_service(
+    repository: ClientRepository = Depends(get_client_repository),
+) -> ClientService:
+    """Dependency that provides a client service instance."""
+
+    return ClientService(repository)
+
+
+@router.get(
+    "/",
+    response_model=ClientListResponseDTO,
+    summary="Listar clientes",
+    description="Retorna a lista de clientes com suporte a busca e paginação.",
+)
+async def list_clients(
+    search: str | None = Query(None, description="Filtro por nome ou CPF"),
+    page: int = Query(1, ge=1, description="Número da página"),
+    page_size: int = Query(50, ge=1, le=100, description="Itens por página"),
+    service: ClientService = Depends(get_client_service),
+) -> ClientListResponseDTO:
+    """Return paginated list of clients."""
+
+    result = await service.list_clients(search=search, page=page, page_size=page_size)
+    return result
+
+
+@router.post(
+    "/",
+    response_model=DataResponse[ClientResponseDTO],
+    status_code=status.HTTP_201_CREATED,
+    summary="Cadastrar cliente",
+    description="Cria um novo cliente manualmente.",
+)
+async def create_client(
+    payload: ClientCreateDTO,
+    service: ClientService = Depends(get_client_service),
+) -> DataResponse[ClientResponseDTO]:
+    """Create a new client entry."""
+
+    result = await service.create_client(payload)
+    if not result["success"]:
+        status_code = status.HTTP_400_BAD_REQUEST
+        if result.get("error_code") == "duplicate":
+            status_code = status.HTTP_409_CONFLICT
+        raise HTTPException(status_code=status_code, detail=result["message"])
+
+    return DataResponse(
+        success=True,
+        message=result["message"],
+        data=result["client"],
+    )
+
+
+@router.get(
+    "/{client_id}",
+    response_model=ClientDetailResponseDTO,
+    summary="Detalhar cliente",
+    description="Retorna os dados completos do cliente com histórico de agendamentos.",
+)
+async def get_client(
+    client_id: str,
+    service: ClientService = Depends(get_client_service),
+) -> ClientDetailResponseDTO:
+    """Retrieve client with full history."""
+
+    result = await service.get_client_detail(client_id)
+    if not result.success:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=result.message)
+    return result
+
+
+@router.put(
+    "/{client_id}",
+    response_model=DataResponse[ClientResponseDTO],
+    summary="Atualizar cliente",
+    description="Atualiza informações cadastrais de um cliente existente.",
+)
+async def update_client(
+    client_id: str,
+    payload: ClientUpdateDTO,
+    service: ClientService = Depends(get_client_service),
+) -> DataResponse[ClientResponseDTO]:
+    """Update client data."""
+
+    result = await service.update_client(client_id, payload)
+    if not result["success"]:
+        if result.get("error_code") == "not_found":
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=result["message"])
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=result["message"])
+
+    return DataResponse(
+        success=True,
+        message=result["message"],
+        data=result["client"],
+    )

--- a/backend/src/presentation/api/v1/router.py
+++ b/backend/src/presentation/api/v1/router.py
@@ -14,6 +14,7 @@ from src.presentation.api.v1.endpoints import (
     appointments,
     auth,
     cars,
+    clients,
     collectors,
     drivers,
     logistics_packages,
@@ -52,6 +53,10 @@ api_v1_router.include_router(
     collectors.router, prefix="/collectors", tags=["Collectors"]
 )
 
+api_v1_router.include_router(
+    clients.router, prefix="/clients", tags=["Clients"]
+)
+
 api_v1_router.include_router(cars.router, prefix="/cars", tags=["Cars"])
 
 api_v1_router.include_router(
@@ -85,6 +90,7 @@ async def api_v1_root() -> dict[str, Any]:
             "appointments": f"{settings.api_v1_prefix}/appointments",
             "drivers": f"{settings.api_v1_prefix}/drivers",
             "collectors": f"{settings.api_v1_prefix}/collectors",
+            "clients": f"{settings.api_v1_prefix}/clients",
             "cars": f"{settings.api_v1_prefix}/cars",
             "logistics_packages": f"{settings.api_v1_prefix}/logistics-packages",
             "reports": f"{settings.api_v1_prefix}/reports",

--- a/backend/tests/test_appointment_api.py
+++ b/backend/tests/test_appointment_api.py
@@ -96,6 +96,7 @@ def test_create_appointment_success(client: TestClient) -> None:
         "hora_agendamento": "09:00",
         "status": "Confirmado",
         "telefone": "11999988888",
+        "cpf": "12345678901",
     }
 
     service_mock = MagicMock()
@@ -143,6 +144,7 @@ def test_create_appointment_error_responses(
         "hora_agendamento": "09:00",
         "status": "Confirmado",
         "telefone": "11999988888",
+        "cpf": "12345678901",
     }
 
     service_mock = MagicMock()

--- a/backend/tests/test_appointment_service.py
+++ b/backend/tests/test_appointment_service.py
@@ -36,6 +36,7 @@ async def test_create_appointment_success() -> None:
         hora_agendamento="09:00",
         status="Confirmado",
         telefone="11999988888",
+        cpf="12345678901",
     )
 
     result = await service.create_appointment(dto, created_by="Ana Admin")
@@ -63,6 +64,7 @@ async def test_create_appointment_duplicate() -> None:
         hora_agendamento="09:00",
         status="Confirmado",
         telefone="11999988888",
+        cpf="12345678901",
     )
 
     result = await service.create_appointment(dto, created_by="Ana Admin")
@@ -132,6 +134,7 @@ async def test_create_appointment_validation_error() -> None:
         hora_agendamento="09:00",
         status="Status-Invalido",
         telefone="11999988888",
+        cpf="12345678901",
     )
 
     result = await service.create_appointment(dto, created_by="Ana Admin")
@@ -158,6 +161,7 @@ async def test_create_appointment_internal_error() -> None:
         hora_agendamento="09:00",
         status="Confirmado",
         telefone="11999988888",
+        cpf="12345678901",
     )
 
     result = await service.create_appointment(dto, created_by="Ana Admin")
@@ -228,6 +232,7 @@ async def test_create_appointment_missing_phone() -> None:
         data_agendamento=datetime(2025, 1, 10, 9, 0),
         hora_agendamento="09:00",
         status="Confirmado",
+        cpf="12345678901",
     )
 
     result = await service.create_appointment(dto, created_by="Ana Admin")
@@ -254,6 +259,7 @@ async def test_create_appointment_sets_agendado_por_when_status_agendado() -> No
         hora_agendamento="09:00",
         status="Agendado",
         telefone="11999988888",
+        cpf="12345678901",
     )
 
     result = await service.create_appointment(dto, created_by="Ana Admin")
@@ -301,6 +307,7 @@ async def test_create_appointment_with_logistics_package() -> None:
         status="Confirmado",
         telefone="11999988888",
         logistics_package_id=str(package.id),
+        cpf="12345678901",
     )
 
     result = await service.create_appointment(dto, created_by="Ana Admin")
@@ -341,6 +348,7 @@ async def test_create_appointment_invalid_logistics_package() -> None:
         status="Confirmado",
         telefone="11999988888",
         logistics_package_id="missing",
+        cpf="12345678901",
     )
 
     result = await service.create_appointment(dto, created_by="Ana Admin")
@@ -380,6 +388,7 @@ async def test_create_appointment_with_tags_success() -> None:
         status="Confirmado",
         telefone="11999988888",
         tags=[tag_id],
+        cpf="12345678901",
     )
 
     result = await service.create_appointment(dto, created_by="Ana Admin")
@@ -414,6 +423,7 @@ async def test_create_appointment_with_invalid_tag() -> None:
         status="Confirmado",
         telefone="11999988888",
         tags=[str(uuid4())],
+        cpf="12345678901",
     )
 
     result = await service.create_appointment(dto, created_by="Ana Admin")
@@ -448,6 +458,7 @@ async def test_create_appointment_exceeds_tag_limit() -> None:
         status="Confirmado",
         telefone="11999988888",
         tags=[str(uuid4()), str(uuid4())],
+        cpf="12345678901",
     )
 
     result = await service.create_appointment(dto, created_by="Ana Admin")

--- a/backend/tests/test_client_service.py
+++ b/backend/tests/test_client_service.py
@@ -1,0 +1,104 @@
+import pytest
+
+from src.application.services.client_service import ClientService
+from src.domain.entities.appointment import Appointment
+from src.domain.entities.client import Client, ClientAppointmentHistoryEntry
+from src.domain.repositories.client_repository_interface import ClientRepositoryInterface
+
+
+class InMemoryClientRepository(ClientRepositoryInterface):
+    def __init__(self) -> None:
+        self.storage: dict[str, Client] = {}
+
+    async def ensure_indexes(self) -> None:  # pragma: no cover - not needed for memory repo
+        return None
+
+    async def create(self, client: Client) -> Client:
+        self.storage[str(client.id)] = client
+        return client
+
+    async def update(self, client: Client) -> Client:
+        self.storage[str(client.id)] = client
+        return client
+
+    async def find_by_id(self, client_id: str) -> Client | None:
+        return self.storage.get(client_id)
+
+    async def find_by_cpf(self, cpf: str) -> Client | None:
+        for client in self.storage.values():
+            if client.cpf == cpf:
+                return client
+        return None
+
+    async def list_clients(self, search=None, skip: int = 0, limit: int = 50):
+        clients = list(self.storage.values())
+        return clients[skip : skip + limit], len(clients)
+
+    async def append_history_entry(self, client_id: str, entry: ClientAppointmentHistoryEntry) -> None:
+        client = self.storage.get(client_id)
+        if not client:
+            return
+        if not any(item.appointment_id == entry.appointment_id for item in client.historico_agendamentos):
+            client.historico_agendamentos.append(entry)
+            client.total_agendamentos += 1
+            self.storage[client_id] = client
+
+
+@pytest.mark.asyncio
+async def test_sync_from_appointment_creates_client() -> None:
+    repository = InMemoryClientRepository()
+    service = ClientService(repository)
+
+    appointment = Appointment(
+        nome_marca='Marca',
+        nome_unidade='Unidade',
+        nome_paciente='Paciente Teste',
+        telefone='11999999999',
+        status='Confirmado',
+        cpf='12345678901',
+    )
+
+    await service.sync_from_appointment(appointment)
+
+    created = await repository.find_by_cpf('12345678901')
+    assert created is not None
+    assert created.nome == 'Paciente Teste'
+    assert created.total_agendamentos == 1
+    assert len(created.historico_agendamentos) == 1
+
+
+@pytest.mark.asyncio
+async def test_sync_from_appointment_updates_existing_client() -> None:
+    repository = InMemoryClientRepository()
+    existing = Client(
+        nome='Nome Original',
+        cpf='12345678901',
+        telefone='11988887777',
+        total_agendamentos=1,
+        historico_agendamentos=[
+            ClientAppointmentHistoryEntry(
+                appointment_id='existing',
+                status='Pendente',
+            )
+        ],
+    )
+    await repository.create(existing)
+    service = ClientService(repository)
+
+    appointment = Appointment(
+        nome_marca='Marca',
+        nome_unidade='Unidade',
+        nome_paciente='Paciente Atualizado',
+        telefone='21900001111',
+        status='Confirmado',
+        cpf='12345678901',
+    )
+
+    await service.sync_from_appointment(appointment)
+
+    updated = await repository.find_by_cpf('12345678901')
+    assert updated is not None
+    assert updated.nome == 'Paciente Atualizado'
+    assert updated.telefone == '21900001111'
+    assert updated.total_agendamentos == 2
+    assert any(item.appointment_id == str(appointment.id) for item in updated.historico_agendamentos)

--- a/frontend/src/components/AppointmentFormModal.tsx
+++ b/frontend/src/components/AppointmentFormModal.tsx
@@ -75,6 +75,11 @@ const formSchema = z.object({
       const digits = value.replace(/\D/g, '');
       return digits.length === 10 || digits.length === 11;
     }, 'Telefone deve conter 10 ou 11 dígitos'),
+  cpf: z
+    .string()
+    .trim()
+    .min(1, 'Informe o CPF do paciente')
+    .refine((value) => value.replace(/\D/g, '').length === 11, 'CPF deve conter 11 dígitos'),
   carro: z.string().trim().default(''),
   logistics_package_id: z.string().trim().default(''),
   observacoes: z.string().trim().default(''),
@@ -139,6 +144,7 @@ export function AppointmentFormModal({
       nome_marca: DEFAULT_BRAND,
       nome_unidade: DEFAULT_UNIT,
       nome_paciente: '',
+      cpf: '',
       date: '',
       time: '',
       tipo_consulta: '',
@@ -228,6 +234,7 @@ export function AppointmentFormModal({
     }
 
     const phoneDigits = values.telefone.replace(/\D/g, '');
+    const cpfDigits = values.cpf.replace(/\D/g, '');
 
     const payload: AppointmentCreateRequest = {
       nome_marca: values.nome_marca.trim(),
@@ -237,6 +244,7 @@ export function AppointmentFormModal({
       cip: values.cip.trim() || undefined,
       status: values.status || DEFAULT_STATUS,
       telefone: phoneDigits,
+      cpf: cpfDigits,
       carro: values.carro.trim() || undefined,
       observacoes: values.observacoes.trim() || undefined,
       driver_id: values.driver_id || undefined,
@@ -401,6 +409,19 @@ export function AppointmentFormModal({
             />
             {errors.telefone && (
               <p className="mt-1 text-sm text-red-600">{errors.telefone.message}</p>
+            )}
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">CPF *</label>
+            <input
+              type="text"
+              {...register('cpf')}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+              placeholder="00000000000"
+              disabled={isSubmitting}
+            />
+            {errors.cpf && (
+              <p className="mt-1 text-sm text-red-600">{errors.cpf.message}</p>
             )}
           </div>
           {logisticsPackages.length > 0 && (

--- a/frontend/src/components/ClientFormModal.tsx
+++ b/frontend/src/components/ClientFormModal.tsx
@@ -1,0 +1,207 @@
+import { useEffect } from 'react';
+import { type SubmitHandler, useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+
+import { Modal } from './ui/Modal';
+import type { Client } from '../types/client';
+
+interface ClientFormModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (data: ClientFormValues) => Promise<void> | void;
+  isSubmitting?: boolean;
+  client?: Client;
+  serverError?: string | null;
+}
+
+const formSchema = z.object({
+  nome: z.string().trim().min(1, 'Informe o nome do cliente'),
+  cpf: z
+    .string()
+    .trim()
+    .min(1, 'Informe o CPF do cliente')
+    .refine((value) => value.replace(/\D/g, '').length === 11, 'CPF deve conter 11 dígitos'),
+  telefone: z
+    .string()
+    .optional()
+    .transform((value) => (value ? value.trim() : ''))
+    .refine((value) => {
+      if (!value) return true;
+      const digits = value.replace(/\D/g, '');
+      return digits.length === 10 || digits.length === 11;
+    }, 'Telefone deve conter 10 ou 11 dígitos')
+    .default(''),
+  email: z
+    .string()
+    .optional()
+    .transform((value) => (value ? value.trim() : ''))
+    .refine((value) => {
+      if (!value) return true;
+      return /\S+@\S+\.\S+/.test(value);
+    }, 'Informe um email válido')
+    .default(''),
+  observacoes: z.string().optional().transform((value) => value?.trim() ?? '').default(''),
+});
+
+export type ClientFormValues = z.infer<typeof formSchema>;
+
+export function ClientFormModal({
+  isOpen,
+  onClose,
+  onSubmit,
+  isSubmitting = false,
+  client,
+  serverError,
+}: ClientFormModalProps) {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<ClientFormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      nome: '',
+      cpf: '',
+      telefone: '',
+      email: '',
+      observacoes: '',
+    },
+  });
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    if (client) {
+      reset({
+        nome: client.nome,
+        cpf: client.cpf,
+        telefone: client.telefone ?? '',
+        email: client.email ?? '',
+        observacoes: client.observacoes ?? '',
+      });
+    } else {
+      reset({
+        nome: '',
+        cpf: '',
+        telefone: '',
+        email: '',
+        observacoes: '',
+      });
+    }
+  }, [client, isOpen, reset]);
+
+  const onSubmitForm: SubmitHandler<ClientFormValues> = (values) => {
+    const phoneDigits = values.telefone ? values.telefone.replace(/\D/g, '') : undefined;
+    const cpfDigits = values.cpf.replace(/\D/g, '');
+
+    onSubmit({
+      nome: values.nome.trim(),
+      cpf: cpfDigits,
+      telefone: phoneDigits ?? '',
+      email: values.email || '',
+      observacoes: values.observacoes || '',
+    });
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={client ? 'Editar Cliente' : 'Novo Cliente'}
+      size="md"
+    >
+      <form className="space-y-4" onSubmit={handleSubmit(onSubmitForm)}>
+        <div>
+          <label className="block text-sm font-medium text-gray-700">Nome *</label>
+          <input
+            type="text"
+            {...register('nome')}
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+            placeholder="Nome completo"
+            disabled={isSubmitting}
+          />
+          {errors.nome && <p className="mt-1 text-sm text-red-600">{errors.nome.message}</p>}
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700">CPF *</label>
+          <input
+            type="text"
+            {...register('cpf')}
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+            placeholder="00000000000"
+            disabled={isSubmitting || Boolean(client)}
+          />
+          {errors.cpf && <p className="mt-1 text-sm text-red-600">{errors.cpf.message}</p>}
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Telefone</label>
+            <input
+              type="tel"
+              {...register('telefone')}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+              placeholder="11999999999"
+              disabled={isSubmitting}
+            />
+            {errors.telefone && (
+              <p className="mt-1 text-sm text-red-600">{errors.telefone.message}</p>
+            )}
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Email</label>
+            <input
+              type="email"
+              {...register('email')}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+              placeholder="email@dominio.com"
+              disabled={isSubmitting}
+            />
+            {errors.email && <p className="mt-1 text-sm text-red-600">{errors.email.message}</p>}
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700">Observações</label>
+          <textarea
+            rows={4}
+            {...register('observacoes')}
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+            placeholder="Informações relevantes, preferências, etc."
+            disabled={isSubmitting}
+          />
+        </div>
+
+        {serverError && (
+          <p className="text-sm text-red-600" role="alert">
+            {serverError}
+          </p>
+        )}
+
+        <div className="flex justify-end gap-3 pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+            disabled={isSubmitting}
+          >
+            Cancelar
+          </button>
+          <button
+            type="submit"
+            className="inline-flex items-center rounded-md border border-transparent bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50"
+            disabled={isSubmitting}
+          >
+            {client ? 'Salvar alterações' : 'Cadastrar cliente'}
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/frontend/src/components/ClientHistoryModal.tsx
+++ b/frontend/src/components/ClientHistoryModal.tsx
@@ -1,0 +1,108 @@
+import { Modal } from './ui/Modal';
+import type { ClientDetail, ClientHistoryEntry } from '../types/client';
+
+interface ClientHistoryModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  client: ClientDetail | null;
+}
+
+const formatDate = (value?: string | null) => {
+  if (!value) return '—';
+  try {
+    return new Date(value).toLocaleDateString('pt-BR');
+  } catch {
+    return value;
+  }
+};
+
+const formatTime = (value?: string | null) => (value ? value : '—');
+
+const sortHistory = (history: ClientHistoryEntry[]) =>
+  [...history].sort((a, b) => {
+    const dateA = a.data_agendamento ? new Date(a.data_agendamento).getTime() : 0;
+    const dateB = b.data_agendamento ? new Date(b.data_agendamento).getTime() : 0;
+    return dateB - dateA;
+  });
+
+export function ClientHistoryModal({ isOpen, onClose, client }: ClientHistoryModalProps) {
+  if (!client) {
+    return null;
+  }
+
+  const history = sortHistory(client.historico_agendamentos);
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title={`Histórico de ${client.nome}`} size="lg">
+      <div className="space-y-4">
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+          <div>
+            <p className="text-sm text-gray-500">CPF</p>
+            <p className="text-base font-medium text-gray-900">{client.cpf}</p>
+          </div>
+          {client.telefone ? (
+            <div>
+              <p className="text-sm text-gray-500">Telefone</p>
+              <p className="text-base font-medium text-gray-900">{client.telefone}</p>
+            </div>
+          ) : null}
+          {client.email ? (
+            <div>
+              <p className="text-sm text-gray-500">Email</p>
+              <p className="text-base font-medium text-gray-900">{client.email}</p>
+            </div>
+          ) : null}
+          {client.total_agendamentos > 0 ? (
+            <div>
+              <p className="text-sm text-gray-500">Total de agendamentos</p>
+              <p className="text-base font-medium text-gray-900">{client.total_agendamentos}</p>
+            </div>
+          ) : null}
+        </div>
+
+        <div className="overflow-x-auto rounded-lg border border-gray-200">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th scope="col" className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                  Data
+                </th>
+                <th scope="col" className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                  Hora
+                </th>
+                <th scope="col" className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                  Unidade
+                </th>
+                <th scope="col" className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                  Marca
+                </th>
+                <th scope="col" className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                  Status
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200 bg-white">
+              {history.length === 0 ? (
+                <tr>
+                  <td colSpan={5} className="px-4 py-6 text-center text-sm text-gray-500">
+                    Nenhum agendamento registrado para este cliente.
+                  </td>
+                </tr>
+              ) : (
+                history.map((entry) => (
+                  <tr key={entry.appointment_id}>
+                    <td className="px-4 py-3 text-sm text-gray-900">{formatDate(entry.data_agendamento)}</td>
+                    <td className="px-4 py-3 text-sm text-gray-700">{formatTime(entry.hora_agendamento)}</td>
+                    <td className="px-4 py-3 text-sm text-gray-700">{entry.nome_unidade ?? '—'}</td>
+                    <td className="px-4 py-3 text-sm text-gray-700">{entry.nome_marca ?? '—'}</td>
+                    <td className="px-4 py-3 text-sm font-medium text-gray-900">{entry.status ?? '—'}</td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/components/ClientTable.tsx
+++ b/frontend/src/components/ClientTable.tsx
@@ -1,0 +1,87 @@
+import type { Client } from '../types/client';
+import { maskCpf } from '../utils/appointmentViewModel';
+
+interface ClientTableProps {
+  clients: Client[];
+  onEdit: (client: Client) => void;
+  onViewHistory: (client: Client) => void;
+  isLoading?: boolean;
+}
+
+export function ClientTable({ clients, onEdit, onViewHistory, isLoading = false }: ClientTableProps) {
+  if (isLoading) {
+    return (
+      <div className="flex h-40 items-center justify-center rounded-lg border border-gray-200">
+        <p className="text-sm text-gray-500">Carregando clientes...</p>
+      </div>
+    );
+  }
+
+  if (clients.length === 0) {
+    return (
+      <div className="flex h-40 items-center justify-center rounded-lg border border-dashed border-gray-200">
+        <p className="text-sm text-gray-500">Nenhum cliente encontrado.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-lg border border-gray-200">
+      <table className="min-w-full divide-y divide-gray-200">
+        <thead className="bg-gray-50">
+          <tr>
+            <th scope="col" className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+              Nome
+            </th>
+            <th scope="col" className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+              CPF
+            </th>
+            <th scope="col" className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+              Telefone
+            </th>
+            <th scope="col" className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+              Último agendamento
+            </th>
+            <th scope="col" className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+              Ações
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-200 bg-white">
+          {clients.map((client) => (
+            <tr key={client.id} className="hover:bg-gray-50">
+              <td className="whitespace-nowrap px-4 py-3 text-sm font-medium text-gray-900">{client.nome}</td>
+              <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-700">{maskCpf(client.cpf)}</td>
+              <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-700">
+                {client.telefone ? client.telefone : '—'}
+              </td>
+              <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-700">
+                {client.ultimo_agendamento_em
+                  ? new Date(client.ultimo_agendamento_em).toLocaleDateString('pt-BR')
+                  : '—'}
+              </td>
+              <td className="px-4 py-3 text-sm text-gray-700">
+                <div className="flex flex-wrap items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => onViewHistory(client)}
+                    className="inline-flex items-center rounded-md border border-gray-300 bg-white px-3 py-1 text-xs font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+                  >
+                    Histórico
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => onEdit(client)}
+                    className="inline-flex items-center rounded-md border border-transparent bg-blue-600 px-3 py-1 text-xs font-medium text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+                  >
+                    Editar
+                  </button>
+                </div>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/config/appRoutes.tsx
+++ b/frontend/src/config/appRoutes.tsx
@@ -3,6 +3,7 @@ import { ROLES, type Role } from '../constants/roles';
 import { AppointmentsPage } from '../pages/AppointmentsPage';
 import { CarsPage } from '../pages/CarsPage';
 import { CollectorsPage } from '../pages/CollectorsPage';
+import { ClientsPage } from '../pages/ClientsPage';
 import AdminDashboardPage from '../pages/dashboard/AdminDashboardPage';
 import OperationDashboardPage from '../pages/dashboard/OperationDashboardPage';
 import { DriversPage } from '../pages/DriversPage';
@@ -53,6 +54,13 @@ export const APP_ROUTES: AppRoute[] = [
     Component: CollectorsPage,
     allowedRoles: [ROLES.ADMIN, ROLES.COLABORADOR],
     breadcrumb: ['Cadastros', 'Coletoras'],
+  },
+  {
+    id: 'clients',
+    path: '/cadastros/clientes',
+    Component: ClientsPage,
+    allowedRoles: [ROLES.ADMIN, ROLES.COLABORADOR],
+    breadcrumb: ['Cadastros', 'Clientes'],
   },
   {
     id: 'cars',

--- a/frontend/src/config/navigationConfig.tsx
+++ b/frontend/src/config/navigationConfig.tsx
@@ -68,6 +68,15 @@ export const NAVIGATION_ITEMS: NavigationItem[] = [
     allowedRoles: [ROLES.ADMIN, ROLES.COLABORADOR],
   },
   {
+    id: 'clientes',
+    label: 'Clientes',
+    description: 'Gerencie pacientes e históricos',
+    group: 'cadastros',
+    icon: UsersIcon,
+    to: '/cadastros/clientes',
+    allowedRoles: [ROLES.ADMIN, ROLES.COLABORADOR],
+  },
+  {
     id: 'carros',
     label: 'Carros',
     description: 'Gerencie a frota disponível',

--- a/frontend/src/pages/ClientsPage.tsx
+++ b/frontend/src/pages/ClientsPage.tsx
@@ -1,0 +1,284 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+
+import { ClientFormModal, type ClientFormValues } from '../components/ClientFormModal';
+import { ClientHistoryModal } from '../components/ClientHistoryModal';
+import { ClientTable } from '../components/ClientTable';
+import { clientAPI } from '../services/api';
+import type {
+  Client,
+  ClientCreateRequest,
+  ClientDataResponse,
+  ClientDetail,
+  ClientDetailResponse,
+  ClientUpdateRequest,
+} from '../types/client';
+
+const CLIENTS_PAGE_SIZE = 10;
+
+export function ClientsPage() {
+  const queryClient = useQueryClient();
+  const [searchInput, setSearchInput] = useState('');
+  const [searchTerm, setSearchTerm] = useState('');
+  const [page, setPage] = useState(1);
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const [selectedClient, setSelectedClient] = useState<Client | undefined>();
+  const [formError, setFormError] = useState<string | null>(null);
+  const [historyClient, setHistoryClient] = useState<ClientDetail | null>(null);
+  const [isHistoryOpen, setIsHistoryOpen] = useState(false);
+  const [historyError, setHistoryError] = useState<string | null>(null);
+
+  const {
+    data: clientsData,
+    isLoading: isLoadingClients,
+    isError: isClientsError,
+  } = useQuery({
+    queryKey: ['clients', { searchTerm, page }],
+    queryFn: () =>
+      clientAPI.getClients({
+        search: searchTerm || undefined,
+        page,
+        page_size: CLIENTS_PAGE_SIZE,
+      }),
+    keepPreviousData: true,
+  });
+
+  const createClientMutation = useMutation<ClientDataResponse, unknown, ClientCreateRequest>({
+    mutationFn: clientAPI.createClient,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['clients'] });
+      setIsFormOpen(false);
+      setSelectedClient(undefined);
+      setFormError(null);
+    },
+    onError: (error: any) => {
+      const message = error.response?.data?.detail || error.response?.data?.message || 'Erro ao cadastrar cliente';
+      setFormError(message);
+    },
+  });
+
+  const updateClientMutation = useMutation<
+    ClientDataResponse,
+    unknown,
+    { id: string; data: ClientUpdateRequest }
+  >({
+    mutationFn: ({ id, data }) => clientAPI.updateClient(id, data),
+    onSuccess: (response, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['clients'] });
+      if (isHistoryOpen && historyClient && historyClient.id === variables.id) {
+        setHistoryClient(response.data);
+      }
+      setIsFormOpen(false);
+      setSelectedClient(undefined);
+      setFormError(null);
+    },
+    onError: (error: any) => {
+      const message = error.response?.data?.detail || error.response?.data?.message || 'Erro ao atualizar cliente';
+      setFormError(message);
+    },
+  });
+
+  const historyMutation = useMutation<ClientDetailResponse, unknown, string>({
+    mutationFn: (id) => clientAPI.getClientDetail(id),
+    onSuccess: (response) => {
+      setHistoryClient(response.client);
+      setHistoryError(null);
+      setIsHistoryOpen(true);
+    },
+    onError: (error: any) => {
+      const message = error.response?.data?.detail || 'Não foi possível carregar o histórico do cliente';
+      setHistoryError(message);
+    },
+  });
+
+  const clients = clientsData?.clients ?? [];
+  const pagination = clientsData?.pagination;
+
+  const handleSearchSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    setSearchTerm(searchInput.trim());
+    setPage(1);
+  };
+
+  const handleResetSearch = () => {
+    setSearchInput('');
+    setSearchTerm('');
+    setPage(1);
+  };
+
+  const handleNewClient = () => {
+    setSelectedClient(undefined);
+    setFormError(null);
+    setIsFormOpen(true);
+  };
+
+  const handleEditClient = (client: Client) => {
+    setSelectedClient(client);
+    setFormError(null);
+    setIsFormOpen(true);
+  };
+
+  const sanitizeFormValues = (values: ClientFormValues): ClientFormValues => ({
+    nome: values.nome.trim(),
+    cpf: values.cpf.replace(/\D/g, ''),
+    telefone: values.telefone ? values.telefone.replace(/\D/g, '') : '',
+    email: values.email ? values.email.trim() : '',
+    observacoes: values.observacoes ? values.observacoes.trim() : '',
+  });
+
+  const handleFormSubmit = (values: ClientFormValues) => {
+    const sanitized = sanitizeFormValues(values);
+
+    if (selectedClient) {
+      const updatePayload: ClientUpdateRequest = {
+        nome: sanitized.nome,
+        telefone: sanitized.telefone || undefined,
+        email: sanitized.email || undefined,
+        observacoes: sanitized.observacoes || undefined,
+      };
+      updateClientMutation.mutate({ id: selectedClient.id, data: updatePayload });
+      return;
+    }
+
+    createClientMutation.mutate({
+      nome: sanitized.nome,
+      cpf: sanitized.cpf,
+      telefone: sanitized.telefone || undefined,
+      email: sanitized.email || undefined,
+      observacoes: sanitized.observacoes || undefined,
+    });
+  };
+
+  const handleCloseForm = () => {
+    setIsFormOpen(false);
+    setSelectedClient(undefined);
+    setFormError(null);
+  };
+
+  const handleViewHistory = (client: Client) => {
+    setHistoryError(null);
+    historyMutation.mutate(client.id);
+  };
+
+  const handleCloseHistory = () => {
+    setIsHistoryOpen(false);
+    setHistoryClient(null);
+  };
+
+  const isSubmitting = createClientMutation.isPending || updateClientMutation.isPending;
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+        <div className="mb-8 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h1 className="text-3xl font-bold text-gray-900">Gestão de Clientes</h1>
+            <p className="text-gray-600">Acompanhe os pacientes cadastrados e seus agendamentos.</p>
+          </div>
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={handleNewClient}
+              className="inline-flex items-center rounded-md border border-transparent bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+            >
+              Novo cliente
+            </button>
+          </div>
+        </div>
+
+        <form className="mb-6" onSubmit={handleSearchSubmit}>
+          <div className="flex flex-col gap-3 rounded-lg bg-white p-4 shadow-sm md:flex-row md:items-center">
+            <div className="flex-1">
+              <label htmlFor="client-search" className="block text-sm font-medium text-gray-700">
+                Buscar por nome ou CPF
+              </label>
+              <input
+                id="client-search"
+                type="text"
+                value={searchInput}
+                onChange={(event) => setSearchInput(event.target.value)}
+                className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+                placeholder="Ex.: Maria Silva ou 12345678901"
+              />
+            </div>
+            <div className="flex items-center gap-3">
+              <button
+                type="submit"
+                className="inline-flex items-center rounded-md border border-transparent bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+              >
+                Buscar
+              </button>
+              <button
+                type="button"
+                onClick={handleResetSearch}
+                className="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+              >
+                Limpar
+              </button>
+            </div>
+          </div>
+        </form>
+
+        {historyError ? (
+          <div className="mb-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            {historyError}
+          </div>
+        ) : null}
+
+        {isClientsError ? (
+          <div className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            Não foi possível carregar a lista de clientes. Tente novamente em instantes.
+          </div>
+        ) : (
+          <ClientTable
+            clients={clients}
+            onEdit={handleEditClient}
+            onViewHistory={handleViewHistory}
+            isLoading={isLoadingClients}
+          />
+        )}
+
+        {pagination && (pagination.total_pages > 1 || pagination.has_previous || pagination.has_next) ? (
+          <div className="mt-6 flex items-center justify-between">
+            <p className="text-sm text-gray-600">
+              Página {pagination.page} de {pagination.total_pages}
+            </p>
+            <div className="flex items-center gap-3">
+              <button
+                type="button"
+                onClick={() => setPage((current) => Math.max(1, current - 1))}
+                disabled={!pagination.has_previous}
+                className="inline-flex items-center rounded-md border border-gray-300 bg-white px-3 py-1 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Anterior
+              </button>
+              <button
+                type="button"
+                onClick={() => setPage((current) => current + 1)}
+                disabled={!pagination.has_next}
+                className="inline-flex items-center rounded-md border border-gray-300 bg-white px-3 py-1 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Próxima
+              </button>
+            </div>
+          </div>
+        ) : null}
+      </div>
+
+      <ClientFormModal
+        isOpen={isFormOpen}
+        onClose={handleCloseForm}
+        onSubmit={handleFormSubmit}
+        isSubmitting={isSubmitting}
+        client={selectedClient}
+        serverError={formError}
+      />
+
+      <ClientHistoryModal
+        isOpen={isHistoryOpen}
+        onClose={handleCloseHistory}
+        client={historyClient}
+      />
+    </div>
+  );
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -58,6 +58,14 @@ import type {
     LogisticsPackageResponse,
     LogisticsPackageUpdateRequest,
 } from '../types/logistics-package';
+import type {
+    ClientCreateRequest,
+    ClientDataResponse,
+    ClientDetailResponse,
+    ClientListParams,
+    ClientListResponse,
+    ClientUpdateRequest,
+} from '../types/client';
 
 const resolveApiBaseUrl = (): string => {
   if (typeof window !== 'undefined' && window.ENV?.API_URL) {
@@ -466,6 +474,48 @@ export const collectorAPI = {
   // Get collector filter options
   getCollectorFilterOptions: async (): Promise<CollectorFilterOptions> => {
     const response = await api.get<CollectorFilterOptions>('/collectors/filter-options');
+    return response.data;
+  },
+};
+
+export const clientAPI = {
+  getClients: async (params: ClientListParams = {}): Promise<ClientListResponse> => {
+    const searchParams = new URLSearchParams();
+
+    if (params.search) searchParams.append('search', params.search);
+    if (params.page) searchParams.append('page', params.page.toString());
+    if (params.page_size) searchParams.append('page_size', params.page_size.toString());
+
+    const query = searchParams.toString();
+    const response = await api.get<ClientListResponse>(
+      `/clients${query ? `?${query}` : ''}`,
+      { withCredentials: true }
+    );
+
+    return response.data;
+  },
+
+  createClient: async (payload: ClientCreateRequest): Promise<ClientDataResponse> => {
+    const response = await api.post<ClientDataResponse>('/clients', payload, {
+      withCredentials: true,
+    });
+    return response.data;
+  },
+
+  updateClient: async (
+    id: string,
+    payload: ClientUpdateRequest
+  ): Promise<ClientDataResponse> => {
+    const response = await api.put<ClientDataResponse>(`/clients/${id}`, payload, {
+      withCredentials: true,
+    });
+    return response.data;
+  },
+
+  getClientDetail: async (id: string): Promise<ClientDetailResponse> => {
+    const response = await api.get<ClientDetailResponse>(`/clients/${id}`, {
+      withCredentials: true,
+    });
     return response.data;
   },
 };

--- a/frontend/src/types/appointment.ts
+++ b/frontend/src/types/appointment.ts
@@ -73,6 +73,7 @@ export interface AppointmentCreateRequest {
   cip?: string;
   status?: string;
   telefone: string;
+  cpf: string;
   carro?: string;
   observacoes?: string;
   driver_id?: string;

--- a/frontend/src/types/client.ts
+++ b/frontend/src/types/client.ts
@@ -1,0 +1,78 @@
+export interface Client {
+  id: string;
+  nome: string;
+  cpf: string;
+  telefone?: string | null;
+  email?: string | null;
+  observacoes?: string | null;
+  total_agendamentos: number;
+  ultimo_agendamento_em?: string | null;
+  ultimo_status?: string | null;
+  ultima_unidade?: string | null;
+  ultima_marca?: string | null;
+  created_at: string;
+  updated_at?: string | null;
+}
+
+export interface ClientHistoryEntry {
+  appointment_id: string;
+  data_agendamento?: string | null;
+  hora_agendamento?: string | null;
+  status?: string | null;
+  nome_unidade?: string | null;
+  nome_marca?: string | null;
+  created_at: string;
+}
+
+export interface ClientCreateRequest {
+  nome: string;
+  cpf: string;
+  telefone?: string | null;
+  email?: string | null;
+  observacoes?: string | null;
+}
+
+export interface ClientUpdateRequest {
+  nome?: string;
+  telefone?: string | null;
+  email?: string | null;
+  observacoes?: string | null;
+}
+
+export interface ClientListParams {
+  search?: string;
+  page?: number;
+  page_size?: number;
+}
+
+export interface ClientPaginationInfo {
+  page: number;
+  page_size: number;
+  total_items: number;
+  total_pages: number;
+  has_next: boolean;
+  has_previous: boolean;
+}
+
+export interface ClientListResponse {
+  success: boolean;
+  message?: string;
+  clients: Client[];
+  pagination: ClientPaginationInfo;
+}
+
+export interface ClientDetail extends Client {
+  historico_agendamentos: ClientHistoryEntry[];
+}
+
+export interface ClientDataResponse {
+  success: boolean;
+  message?: string;
+  data: ClientDetail;
+}
+
+export interface ClientDetailResponse {
+  success: boolean;
+  message?: string;
+  client: ClientDetail;
+}


### PR DESCRIPTION
## Summary
- add client aggregate, repository, and service with API endpoints and Excel/appointment sync
- require CPF on appointment creation and update Excel import feedback for past dates
- add React client management experience with forms, history modal, and navigation entry

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d85f5b926083238fa90073bb435d8e