### PR TITLE
feat: add client management endpoints and UI

### DIFF
--- a/backend/src/application/dtos/appointment_dto.py
+++ b/backend/src/application/dtos/appointment_dto.py
@@ -36,6 +36,7 @@ class AppointmentCreateDTO(BaseModel):
     )
     status: str = Field("Pendente", description="Status do Agendamento")
     telefone: Optional[str] = Field(None, description="Telefone do Paciente")
+    cpf: str = Field(..., description="CPF do paciente (apenas dígitos)")
     carro: Optional[str] = Field(
         None, description="Informações do carro utilizado"
     )

--- a/backend/src/application/dtos/client_dto.py
+++ b/backend/src/application/dtos/client_dto.py
@@ -1,0 +1,97 @@
+"""Data transfer objects for client management."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+from src.application.dtos.appointment_dto import PaginationDTO
+
+
+class ClientAppointmentHistoryDTO(BaseModel):
+    """DTO representing a single appointment entry in the client history."""
+
+    appointment_id: UUID
+    nome_marca: Optional[str] = None
+    nome_unidade: Optional[str] = None
+    nome_paciente: Optional[str] = None
+    data_agendamento: Optional[datetime] = None
+    hora_agendamento: Optional[str] = None
+    status: Optional[str] = None
+    tipo_consulta: Optional[str] = None
+    observacoes: Optional[str] = None
+    created_at: datetime
+
+
+class ClientSummaryDTO(BaseModel):
+    """Compact representation for listing clients."""
+
+    id: UUID
+    nome_completo: str
+    cpf: str
+    cpf_formatado: Optional[str] = None
+    telefone: Optional[str] = None
+    email: Optional[str] = None
+    total_agendamentos: int
+    ultima_data_agendamento: Optional[datetime] = None
+    ultima_unidade: Optional[str] = None
+    ultima_marca: Optional[str] = None
+    ultima_consulta_tipo: Optional[str] = None
+    ultima_consulta_status: Optional[str] = None
+    created_at: datetime
+    updated_at: Optional[datetime] = None
+
+
+class ClientDetailDTO(ClientSummaryDTO):
+    """Detailed representation including history."""
+
+    observacoes: Optional[str] = None
+    numero_convenio: Optional[str] = None
+    nome_convenio: Optional[str] = None
+    carteira_convenio: Optional[str] = None
+    appointment_history: List[ClientAppointmentHistoryDTO] = Field(default_factory=list)
+
+
+class ClientCreateDTO(BaseModel):
+    """Payload for creating a new client manually."""
+
+    nome_completo: str = Field(..., min_length=1)
+    cpf: str = Field(..., min_length=11, max_length=20)
+    telefone: Optional[str] = Field(default=None)
+    email: Optional[str] = Field(default=None)
+    observacoes: Optional[str] = Field(default=None)
+    numero_convenio: Optional[str] = Field(default=None)
+    nome_convenio: Optional[str] = Field(default=None)
+    carteira_convenio: Optional[str] = Field(default=None)
+
+
+class ClientUpdateDTO(BaseModel):
+    """Payload for updating existing clients."""
+
+    nome_completo: Optional[str] = None
+    telefone: Optional[str] = None
+    email: Optional[str] = None
+    observacoes: Optional[str] = None
+    numero_convenio: Optional[str] = None
+    nome_convenio: Optional[str] = None
+    carteira_convenio: Optional[str] = None
+
+
+class ClientResponseDTO(BaseModel):
+    """Response wrapper for single client operations."""
+
+    success: bool
+    message: Optional[str] = None
+    client: ClientDetailDTO
+
+
+class ClientListResponseDTO(BaseModel):
+    """Response for listing clients with pagination."""
+
+    success: bool
+    message: Optional[str] = None
+    clients: List[ClientSummaryDTO]
+    pagination: PaginationDTO

--- a/backend/src/application/services/client_service.py
+++ b/backend/src/application/services/client_service.py
@@ -1,0 +1,360 @@
+"""Service layer for client management and synchronization."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from src.application.dtos.client_dto import (
+    ClientAppointmentHistoryDTO,
+    ClientCreateDTO,
+    ClientDetailDTO,
+    ClientResponseDTO,
+    ClientSummaryDTO,
+    ClientUpdateDTO,
+)
+from src.application.dtos.appointment_dto import PaginationDTO
+from src.domain.entities.appointment import Appointment
+from src.domain.entities.client import AppointmentHistoryEntry, Client
+from src.domain.repositories.client_repository_interface import (
+    ClientRepositoryInterface,
+)
+from src.domain.utils.cpf import format_cpf, is_valid_cpf, normalize_cpf
+
+
+class ClientService:
+    """Application service responsible for client operations."""
+
+    def __init__(self, client_repository: ClientRepositoryInterface):
+        self.client_repository = client_repository
+
+    async def create_client(self, payload: ClientCreateDTO) -> Dict:
+        """Create a client manually from the management screen."""
+
+        try:
+            cpf = normalize_cpf(payload.cpf)
+            if cpf is None or not is_valid_cpf(cpf):
+                return {
+                    "success": False,
+                    "message": "CPF inválido. Informe 11 dígitos válidos.",
+                    "error_code": "validation",
+                }
+
+            existing = await self.client_repository.find_by_cpf(cpf)
+            if existing:
+                return {
+                    "success": False,
+                    "message": "Já existe um cliente cadastrado com este CPF.",
+                    "error_code": "duplicate",
+                }
+
+            client = Client(
+                nome_completo=payload.nome_completo,
+                cpf=cpf,
+                telefone=self._normalize_phone(payload.telefone),
+                email=self._sanitize_text(payload.email),
+                observacoes=self._sanitize_text(payload.observacoes),
+                numero_convenio=self._sanitize_text(payload.numero_convenio),
+                nome_convenio=self._sanitize_text(payload.nome_convenio),
+                carteira_convenio=self._sanitize_text(payload.carteira_convenio),
+            )
+            self._refresh_last_appointment(client)
+
+            created = await self.client_repository.create(client)
+
+            return {
+                "success": True,
+                "message": "Cliente cadastrado com sucesso.",
+                "client": self._to_detail_dto(created),
+            }
+        except ValueError as exc:
+            return {
+                "success": False,
+                "message": str(exc),
+                "error_code": "validation",
+            }
+        except Exception as exc:  # pragma: no cover - defensive branch
+            return {
+                "success": False,
+                "message": f"Erro ao criar cliente: {str(exc)}",
+                "error_code": "internal",
+            }
+
+    async def update_client(self, client_id: str, payload: ClientUpdateDTO) -> Dict:
+        """Update editable fields for an existing client."""
+
+        try:
+            client = await self.client_repository.find_by_id(client_id)
+            if not client:
+                return {
+                    "success": False,
+                    "message": "Cliente não encontrado.",
+                    "error_code": "not_found",
+                }
+
+            updates = payload.model_dump(exclude_unset=True)
+            if not updates:
+                return {
+                    "success": True,
+                    "message": "Nenhuma alteração realizada.",
+                    "client": self._to_detail_dto(client),
+                }
+
+            if "nome_completo" in updates and updates["nome_completo"]:
+                client.nome_completo = updates["nome_completo"]
+
+            if "telefone" in updates:
+                client.telefone = self._normalize_phone(updates["telefone"])
+
+            if "email" in updates:
+                client.email = self._sanitize_text(updates["email"])
+
+            if "observacoes" in updates:
+                client.observacoes = self._sanitize_text(updates["observacoes"])
+
+            if "numero_convenio" in updates:
+                client.numero_convenio = self._sanitize_text(updates["numero_convenio"])
+
+            if "nome_convenio" in updates:
+                client.nome_convenio = self._sanitize_text(updates["nome_convenio"])
+
+            if "carteira_convenio" in updates:
+                client.carteira_convenio = self._sanitize_text(updates["carteira_convenio"])
+
+            client.mark_as_updated()
+            saved = await self.client_repository.update(client)
+
+            return {
+                "success": True,
+                "message": "Cliente atualizado com sucesso.",
+                "client": self._to_detail_dto(saved),
+            }
+        except ValueError as exc:
+            return {
+                "success": False,
+                "message": str(exc),
+                "error_code": "validation",
+            }
+        except Exception as exc:  # pragma: no cover - defensive branch
+            return {
+                "success": False,
+                "message": f"Erro ao atualizar cliente: {str(exc)}",
+                "error_code": "internal",
+            }
+
+    async def list_clients(
+        self, search: Optional[str] = None, page: int = 1, page_size: int = 20
+    ) -> Dict:
+        """List clients with pagination support."""
+
+        skip = (page - 1) * page_size
+        clients = await self.client_repository.find_by_filters(search, skip, page_size)
+        total = await self.client_repository.count(search)
+
+        total_pages = max((total + page_size - 1) // page_size, 1)
+        pagination = PaginationDTO(
+            page=page,
+            page_size=page_size,
+            total_items=total,
+            total_pages=total_pages,
+            has_next=page < total_pages,
+            has_previous=page > 1,
+        )
+
+        return {
+            "success": True,
+            "clients": [self._to_summary_dto(client) for client in clients],
+            "pagination": pagination,
+        }
+
+    async def get_client(self, client_id: str) -> Dict:
+        """Retrieve a client by identifier."""
+
+        client = await self.client_repository.find_by_id(client_id)
+        if not client:
+            return {
+                "success": False,
+                "message": "Cliente não encontrado.",
+                "error_code": "not_found",
+            }
+
+        return {
+            "success": True,
+            "client": self._to_detail_dto(client),
+        }
+
+    async def sync_from_appointment(self, appointment: Appointment) -> None:
+        """Ensure the client record reflects information from the appointment."""
+
+        cpf_candidates = [
+            appointment.cpf,
+            (appointment.documento_normalizado or {}).get("cpf")
+            if appointment.documento_normalizado
+            else None,
+        ]
+
+        cpf_value: Optional[str] = None
+        for candidate in cpf_candidates:
+            normalized = normalize_cpf(candidate)
+            if normalized and is_valid_cpf(normalized):
+                cpf_value = normalized
+                break
+
+        if not cpf_value:
+            return
+
+        history_entry = AppointmentHistoryEntry(
+            appointment_id=appointment.id,
+            nome_marca=appointment.nome_marca,
+            nome_unidade=appointment.nome_unidade,
+            nome_paciente=appointment.nome_paciente,
+            data_agendamento=appointment.data_agendamento,
+            hora_agendamento=appointment.hora_agendamento,
+            status=appointment.status,
+            tipo_consulta=appointment.tipo_consulta,
+            observacoes=appointment.observacoes,
+            created_at=appointment.created_at,
+        )
+
+        client = await self.client_repository.find_by_cpf(cpf_value)
+        if client is None:
+            client = Client(
+                nome_completo=appointment.nome_paciente,
+                cpf=cpf_value,
+                telefone=appointment.telefone,
+                observacoes=appointment.observacoes,
+                numero_convenio=appointment.numero_convenio,
+                nome_convenio=appointment.nome_convenio,
+                carteira_convenio=appointment.carteira_convenio,
+                appointment_history=[history_entry],
+            )
+            self._refresh_last_appointment(client)
+            await self.client_repository.create(client)
+            return
+
+        updated = False
+
+        if appointment.nome_paciente and appointment.nome_paciente != client.nome_completo:
+            client.nome_completo = appointment.nome_paciente
+            updated = True
+
+        if appointment.telefone and appointment.telefone != client.telefone:
+            client.telefone = appointment.telefone
+            updated = True
+
+        if appointment.observacoes and appointment.observacoes != client.observacoes:
+            client.observacoes = appointment.observacoes
+            updated = True
+
+        if appointment.numero_convenio and (
+            appointment.numero_convenio != client.numero_convenio
+        ):
+            client.numero_convenio = appointment.numero_convenio
+            updated = True
+
+        if appointment.nome_convenio and (
+            appointment.nome_convenio != client.nome_convenio
+        ):
+            client.nome_convenio = appointment.nome_convenio
+            updated = True
+
+        if appointment.carteira_convenio and (
+            appointment.carteira_convenio != client.carteira_convenio
+        ):
+            client.carteira_convenio = appointment.carteira_convenio
+            updated = True
+
+        history_map: Dict[str, AppointmentHistoryEntry] = {
+            str(entry.appointment_id): entry for entry in client.appointment_history
+        }
+
+        entry_key = str(history_entry.appointment_id)
+        current_entry = history_map.get(entry_key)
+        if current_entry is None:
+            client.appointment_history.append(history_entry)
+            updated = True
+        elif current_entry != history_entry:
+            history_map[entry_key] = history_entry
+            client.appointment_history = list(history_map.values())
+            updated = True
+
+        if updated:
+            # Keep history sorted by appointment date/creation for consistency
+            client.appointment_history = sorted(
+                client.appointment_history,
+                key=lambda item: item.data_agendamento or item.created_at,
+            )
+
+        self._refresh_last_appointment(client)
+
+        if updated:
+            client.mark_as_updated()
+            await self.client_repository.update(client)
+
+    def _normalize_phone(self, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        digits = "".join(filter(str.isdigit, value))
+        return digits or None
+
+    def _sanitize_text(self, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        trimmed = value.strip()
+        return trimmed or None
+
+    def _refresh_last_appointment(self, client: Client) -> None:
+        if not client.appointment_history:
+            client.total_agendamentos = 0
+            client.ultima_data_agendamento = None
+            client.ultima_unidade = None
+            client.ultima_marca = None
+            client.ultima_consulta_tipo = None
+            client.ultima_consulta_status = None
+            return
+
+        sorted_history = sorted(
+            client.appointment_history,
+            key=lambda item: item.data_agendamento or item.created_at,
+        )
+        client.appointment_history = sorted_history
+        client.total_agendamentos = len(sorted_history)
+
+        latest = sorted_history[-1]
+        client.ultima_data_agendamento = latest.data_agendamento or latest.created_at
+        client.ultima_unidade = latest.nome_unidade
+        client.ultima_marca = latest.nome_marca
+        client.ultima_consulta_tipo = latest.tipo_consulta
+        client.ultima_consulta_status = latest.status
+
+    def _to_summary_dto(self, client: Client) -> ClientSummaryDTO:
+        return ClientSummaryDTO(
+            id=client.id,
+            nome_completo=client.nome_completo,
+            cpf=client.cpf,
+            cpf_formatado=format_cpf(client.cpf),
+            telefone=client.telefone,
+            email=client.email,
+            total_agendamentos=client.total_agendamentos,
+            ultima_data_agendamento=client.ultima_data_agendamento,
+            ultima_unidade=client.ultima_unidade,
+            ultima_marca=client.ultima_marca,
+            ultima_consulta_tipo=client.ultima_consulta_tipo,
+            ultima_consulta_status=client.ultima_consulta_status,
+            created_at=client.created_at,
+            updated_at=client.updated_at,
+        )
+
+    def _to_detail_dto(self, client: Client) -> ClientDetailDTO:
+        summary = self._to_summary_dto(client)
+        history = [
+            ClientAppointmentHistoryDTO(**entry.model_dump())
+            for entry in client.appointment_history
+        ]
+        return ClientDetailDTO(
+            **summary.model_dump(),
+            observacoes=client.observacoes,
+            numero_convenio=client.numero_convenio,
+            nome_convenio=client.nome_convenio,
+            carteira_convenio=client.carteira_convenio,
+            appointment_history=history,
+        )

--- a/backend/src/domain/entities/__init__.py
+++ b/backend/src/domain/entities/__init__.py
@@ -4,8 +4,17 @@ Domain entities module.
 
 from .appointment import Appointment
 from .car import Car
+from .client import Client
 from .collector import Collector
 from .driver import Driver
 from .tag import Tag, TagReference
 
-__all__ = ["Appointment", "Car", "Collector", "Driver", "Tag", "TagReference"]
+__all__ = [
+    "Appointment",
+    "Car",
+    "Client",
+    "Collector",
+    "Driver",
+    "Tag",
+    "TagReference",
+]

--- a/backend/src/domain/entities/client.py
+++ b/backend/src/domain/entities/client.py
@@ -1,0 +1,142 @@
+"""Domain entity representing a clinic client/patient."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field, field_validator
+
+from src.domain.base import Entity
+from src.domain.utils.cpf import is_valid_cpf, normalize_cpf
+
+
+class AppointmentHistoryEntry(BaseModel):
+    """Snapshot of an appointment associated with a client."""
+
+    appointment_id: UUID = Field(..., description="Identificador do agendamento")
+    nome_marca: Optional[str] = Field(
+        None, description="Marca/Clínica utilizada no agendamento"
+    )
+    nome_unidade: Optional[str] = Field(
+        None, description="Unidade relacionada ao agendamento"
+    )
+    nome_paciente: Optional[str] = Field(
+        None, description="Nome do paciente utilizado no agendamento"
+    )
+    data_agendamento: Optional[datetime] = Field(
+        None, description="Data prevista do atendimento"
+    )
+    hora_agendamento: Optional[str] = Field(
+        None, description="Hora prevista do atendimento"
+    )
+    status: Optional[str] = Field(
+        None, description="Status registrado para o agendamento"
+    )
+    tipo_consulta: Optional[str] = Field(
+        None, description="Tipo de consulta ou serviço"
+    )
+    observacoes: Optional[str] = Field(
+        None, description="Observações associadas ao agendamento"
+    )
+    created_at: datetime = Field(
+        default_factory=datetime.utcnow,
+        description="Momento em que o histórico foi registrado",
+    )
+
+
+class Client(Entity):
+    """Client entity storing personal data and appointment history."""
+
+    nome_completo: str = Field(..., description="Nome completo do cliente")
+    cpf: str = Field(..., description="CPF do cliente (apenas dígitos)")
+    telefone: Optional[str] = Field(
+        None, description="Telefone principal de contato"
+    )
+    email: Optional[str] = Field(None, description="Endereço de e-mail do cliente")
+    observacoes: Optional[str] = Field(
+        None, description="Observações gerais sobre o cliente"
+    )
+    numero_convenio: Optional[str] = Field(
+        None, description="Número do convênio vinculado"
+    )
+    nome_convenio: Optional[str] = Field(
+        None, description="Nome do convênio vinculado"
+    )
+    carteira_convenio: Optional[str] = Field(
+        None, description="Identificação/carteira do convênio"
+    )
+    ultima_marca: Optional[str] = Field(
+        None, description="Última marca registrada em um agendamento"
+    )
+    ultima_unidade: Optional[str] = Field(
+        None, description="Última unidade utilizada"
+    )
+    ultima_consulta_tipo: Optional[str] = Field(
+        None, description="Tipo da última consulta registrada"
+    )
+    ultima_consulta_status: Optional[str] = Field(
+        None, description="Status do último agendamento"
+    )
+    ultima_data_agendamento: Optional[datetime] = Field(
+        None, description="Data do último agendamento conhecido"
+    )
+    total_agendamentos: int = Field(
+        0, ge=0, description="Quantidade total de agendamentos vinculados"
+    )
+    appointment_history: List[AppointmentHistoryEntry] = Field(
+        default_factory=list,
+        description="Histórico de agendamentos associados ao cliente",
+    )
+
+    @field_validator("nome_completo")
+    @classmethod
+    def validate_nome_completo(cls, value: str) -> str:
+        """Ensure the client's name is not empty."""
+
+        if not value or not value.strip():
+            raise ValueError("Nome do cliente é obrigatório")
+        return value.strip()
+
+    @field_validator("cpf")
+    @classmethod
+    def validate_cpf(cls, value: str) -> str:
+        """Normalize and validate CPF value."""
+
+        normalized = normalize_cpf(value)
+        if normalized is None or not is_valid_cpf(normalized):
+            raise ValueError("CPF inválido. Informe 11 dígitos válidos.")
+        return normalized
+
+    @field_validator("telefone")
+    @classmethod
+    def validate_telefone(cls, value: Optional[str]) -> Optional[str]:
+        """Normalize and validate phone numbers."""
+
+        if value is None:
+            return None
+
+        digits = (
+            value.strip()
+            .replace(" ", "")
+            .replace("-", "")
+            .replace("(", "")
+            .replace(")", "")
+        )
+
+        if digits and not (10 <= len(digits) <= 11):
+            raise ValueError("Telefone deve conter 10 ou 11 dígitos")
+
+        return digits or None
+
+    @field_validator("email")
+    @classmethod
+    def validate_email(cls, value: Optional[str]) -> Optional[str]:
+        """Trim email values to avoid stray spaces."""
+
+        if value is None:
+            return None
+
+        trimmed = value.strip()
+        return trimmed or None

--- a/backend/src/domain/repositories/__init__.py
+++ b/backend/src/domain/repositories/__init__.py
@@ -4,6 +4,7 @@ Domain repository interfaces.
 
 from .appointment_repository_interface import AppointmentRepositoryInterface
 from .car_repository_interface import CarRepositoryInterface
+from .client_repository_interface import ClientRepositoryInterface
 from .collector_repository_interface import CollectorRepositoryInterface
 from .driver_repository_interface import DriverRepositoryInterface
 from .tag_repository_interface import TagRepositoryInterface
@@ -11,6 +12,7 @@ from .tag_repository_interface import TagRepositoryInterface
 __all__ = [
     "AppointmentRepositoryInterface",
     "CarRepositoryInterface",
+    "ClientRepositoryInterface",
     "CollectorRepositoryInterface",
     "DriverRepositoryInterface",
     "TagRepositoryInterface",

--- a/backend/src/domain/repositories/client_repository_interface.py
+++ b/backend/src/domain/repositories/client_repository_interface.py
@@ -1,0 +1,42 @@
+"""Interface definition for client repositories."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import List, Optional
+
+from src.domain.entities.client import Client
+
+
+class ClientRepositoryInterface(ABC):
+    """Abstract repository contract for client persistence."""
+
+    @abstractmethod
+    async def create(self, client: Client) -> Client:
+        """Persist a new client."""
+
+    @abstractmethod
+    async def update(self, client: Client) -> Client:
+        """Persist changes to an existing client."""
+
+    @abstractmethod
+    async def find_by_id(self, client_id: str) -> Optional[Client]:
+        """Retrieve a client by its identifier."""
+
+    @abstractmethod
+    async def find_by_cpf(self, cpf: str) -> Optional[Client]:
+        """Retrieve a client by CPF."""
+
+    @abstractmethod
+    async def find_by_filters(
+        self, search: Optional[str], skip: int = 0, limit: int = 50
+    ) -> List[Client]:
+        """List clients with optional search and pagination."""
+
+    @abstractmethod
+    async def count(self, search: Optional[str] = None) -> int:
+        """Count total clients for the provided search criteria."""
+
+    @abstractmethod
+    async def ensure_indexes(self) -> None:
+        """Create database indexes if they do not exist."""

--- a/backend/src/domain/utils/cpf.py
+++ b/backend/src/domain/utils/cpf.py
@@ -1,20 +1,60 @@
-"""CPF utilities for normalization and validation helpers."""
+"""CPF utilities for normalization, formatting and validation helpers."""
+
+from __future__ import annotations
 
 import re
 from typing import Optional
 
+__all__ = ["normalize_cpf", "is_valid_cpf", "format_cpf"]
+
 
 def normalize_cpf(cpf: Optional[str]) -> Optional[str]:
-    """Return CPF digits only, preserving None values.
+    """Return CPF digits only, preserving ``None`` values.
 
     Args:
         cpf: CPF value possibly containing formatting characters.
 
     Returns:
-        Normalized CPF with only numbers or None when no value was provided.
+        Normalized CPF with only numbers or ``None`` when no value was provided.
     """
     if cpf is None:
         return None
 
     digits = re.sub(r"\D", "", cpf)
     return digits or None
+
+
+def is_valid_cpf(cpf: Optional[str]) -> bool:
+    """Validate CPF digits using the official checksum algorithm."""
+
+    digits = normalize_cpf(cpf)
+    if digits is None or len(digits) != 11:
+        return False
+
+    if digits == digits[0] * len(digits):
+        return False
+
+    for check_position in (9, 10):
+        total = 0
+        for index in range(check_position):
+            weight = (check_position + 1) - index
+            total += int(digits[index]) * weight
+
+        remainder = (total * 10) % 11
+        if remainder == 10:
+            remainder = 0
+
+        if remainder != int(digits[check_position]):
+            return False
+
+    return True
+
+
+def format_cpf(cpf: Optional[str]) -> Optional[str]:
+    """Return a formatted CPF (XXX.XXX.XXX-XX) when possible."""
+
+    digits = normalize_cpf(cpf)
+    if digits is None or len(digits) != 11:
+        return None
+
+    return f"{digits[:3]}.{digits[3:6]}.{digits[6:9]}-{digits[9:]}"

--- a/backend/src/infrastructure/container.py
+++ b/backend/src/infrastructure/container.py
@@ -9,6 +9,7 @@ from src.infrastructure.repositories.appointment_repository import (
     AppointmentRepository,
 )
 from src.infrastructure.repositories.car_repository import CarRepository
+from src.infrastructure.repositories.client_repository import ClientRepository
 from src.infrastructure.repositories.collector_repository import (
     CollectorRepository,
 )
@@ -42,6 +43,7 @@ class Container:
         self._car_repository: Optional[CarRepository] = None
         self._driver_repository: Optional[DriverRepository] = None
         self._collector_repository: Optional[CollectorRepository] = None
+        self._client_repository: Optional[ClientRepository] = None
         self._user_repository: Optional[UserRepository] = None
         self._notification_repository: Optional[NotificationRepository] = None
         self._tag_repository: Optional[TagRepository] = None
@@ -142,6 +144,14 @@ class Container:
         return self._collector_repository
 
     @property
+    def client_repository(self) -> ClientRepository:
+        """Get client repository instance."""
+
+        if self._client_repository is None:
+            self._client_repository = ClientRepository(self.database)
+        return self._client_repository
+
+    @property
     def logistics_package_repository(self) -> LogisticsPackageRepository:
         """Get logistics package repository instance."""
 
@@ -227,6 +237,7 @@ class Container:
             await self.car_repository.create_indexes()
             await self.driver_repository.create_indexes()
             await self.collector_repository.create_indexes()
+            await self.client_repository.ensure_indexes()
             await self.user_repository.ensure_indexes()
             await self.notification_repository.create_indexes()
             await self.tag_repository.ensure_indexes()
@@ -316,6 +327,12 @@ async def get_collector_repository() -> CollectorRepository:
         CollectorRepository: Repository instance
     """
     return container.collector_repository
+
+
+async def get_client_repository() -> ClientRepository:
+    """Dependency for getting client repository instance."""
+
+    return container.client_repository
 
 
 async def get_user_repository() -> UserRepository:

--- a/backend/src/infrastructure/repositories/__init__.py
+++ b/backend/src/infrastructure/repositories/__init__.py
@@ -3,6 +3,7 @@ Infrastructure repository implementations.
 """
 
 from .appointment_repository import AppointmentRepository
+from .client_repository import ClientRepository
 from .tag_repository import TagRepository
 
-__all__ = ["AppointmentRepository", "TagRepository"]
+__all__ = ["AppointmentRepository", "ClientRepository", "TagRepository"]

--- a/backend/src/infrastructure/repositories/client_repository.py
+++ b/backend/src/infrastructure/repositories/client_repository.py
@@ -1,0 +1,123 @@
+"""MongoDB repository implementation for clients."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Optional
+
+from motor.motor_asyncio import AsyncIOMotorDatabase
+from pymongo import ASCENDING, DESCENDING
+
+from src.domain.entities.client import Client
+from src.domain.repositories.client_repository_interface import (
+    ClientRepositoryInterface,
+)
+
+
+class ClientRepository(ClientRepositoryInterface):
+    """Persistence layer for client management using MongoDB."""
+
+    def __init__(self, database: AsyncIOMotorDatabase):
+        self.database = database
+        self.collection = database.clients
+
+    async def create(self, client: Client) -> Client:
+        data = self._serialize(client)
+        await self.collection.insert_one(data)
+        return client
+
+    async def update(self, client: Client) -> Client:
+        data = self._serialize(client)
+        await self.collection.update_one({"id": data["id"]}, {"$set": data})
+        return client
+
+    async def find_by_id(self, client_id: str) -> Optional[Client]:
+        document = await self.collection.find_one({"id": client_id})
+        if not document:
+            return None
+
+        document.pop("_id", None)
+        return Client(**document)
+
+    async def find_by_cpf(self, cpf: str) -> Optional[Client]:
+        document = await self.collection.find_one({"cpf": cpf})
+        if not document:
+            return None
+
+        document.pop("_id", None)
+        return Client(**document)
+
+    async def find_by_filters(
+        self, search: Optional[str], skip: int = 0, limit: int = 50
+    ) -> List[Client]:
+        query: Dict[str, Any] = {}
+        or_conditions: List[Dict[str, Any]] = []
+
+        if search:
+            trimmed = search.strip()
+            if trimmed:
+                or_conditions.append({"nome_completo": {"$regex": trimmed, "$options": "i"}})
+                or_conditions.append({"email": {"$regex": trimmed, "$options": "i"}})
+
+            digits = re.sub(r"\D", "", trimmed)
+            if digits:
+                or_conditions.append({"cpf": {"$regex": digits}})
+                or_conditions.append({"telefone": {"$regex": digits}})
+
+        if or_conditions:
+            query["$or"] = or_conditions
+
+        cursor = (
+            self.collection.find(query)
+            .skip(skip)
+            .limit(limit)
+            .sort("nome_completo", ASCENDING)
+        )
+
+        clients: List[Client] = []
+        async for document in cursor:
+            document.pop("_id", None)
+            clients.append(Client(**document))
+
+        return clients
+
+    async def count(self, search: Optional[str] = None) -> int:
+        query: Dict[str, Any] = {}
+        or_conditions: List[Dict[str, Any]] = []
+
+        if search:
+            trimmed = search.strip()
+            if trimmed:
+                or_conditions.append({"nome_completo": {"$regex": trimmed, "$options": "i"}})
+                or_conditions.append({"email": {"$regex": trimmed, "$options": "i"}})
+
+            digits = re.sub(r"\D", "", trimmed)
+            if digits:
+                or_conditions.append({"cpf": {"$regex": digits}})
+                or_conditions.append({"telefone": {"$regex": digits}})
+
+        if or_conditions:
+            query["$or"] = or_conditions
+
+        return int(await self.collection.count_documents(query))
+
+    async def ensure_indexes(self) -> None:
+        await self.collection.create_index("cpf", unique=True)
+        await self.collection.create_index("nome_completo", ASCENDING)
+        await self.collection.create_index("created_at", DESCENDING)
+
+    def _serialize(self, client: Client) -> Dict[str, Any]:
+        data = client.model_dump()
+        data["id"] = str(data["id"])
+
+        history = data.get("appointment_history") or []
+        if history:
+            serialized_history = []
+            for entry in history:
+                serialized_entry = dict(entry)
+                if "appointment_id" in serialized_entry:
+                    serialized_entry["appointment_id"] = str(serialized_entry["appointment_id"])
+                serialized_history.append(serialized_entry)
+            data["appointment_history"] = serialized_history
+
+        return data

--- a/backend/src/presentation/api/v1/endpoints/appointments.py
+++ b/backend/src/presentation/api/v1/endpoints/appointments.py
@@ -32,6 +32,7 @@ from src.application.services.address_normalization_service import (
     AddressNormalizationService,
 )
 from src.application.services.appointment_service import AppointmentService
+from src.application.services.client_service import ClientService
 from src.application.services.car_service import CarService
 from src.application.services.dashboard_analytics_service import (
     DashboardAnalyticsService,
@@ -45,12 +46,14 @@ from src.infrastructure.config import Settings, get_settings
 from src.infrastructure.container import (
     get_appointment_repository,
     get_car_repository,
+    get_client_repository,
     get_logistics_package_repository,
     get_tag_repository,
 )
 from src.infrastructure.repositories.appointment_repository import (
     AppointmentRepository,
 )
+from src.infrastructure.repositories.client_repository import ClientRepository
 from src.presentation.dependencies.auth import (
     get_current_active_user,
     get_current_admin_user,
@@ -72,6 +75,7 @@ async def get_appointment_service(
         get_appointment_repository
     ),
     car_repository=Depends(get_car_repository),
+    client_repository: ClientRepository = Depends(get_client_repository),
     logistics_package_repository=Depends(get_logistics_package_repository),
     tag_repository: TagRepository = Depends(get_tag_repository),
     settings: Settings = Depends(get_settings),
@@ -100,12 +104,15 @@ async def get_appointment_service(
     except ValueError:
         # OpenRouter not configured, continue without normalization services
         excel_parser = ExcelParserService(car_service=car_service)
+    client_service = ClientService(client_repository)
+
     return AppointmentService(
         appointment_repository,
         excel_parser,
         logistics_package_repository=logistics_package_repository,
         tag_repository=tag_repository,
         max_tags_per_appointment=settings.max_tags_per_appointment,
+        client_service=client_service,
     )
 
 

--- a/backend/src/presentation/api/v1/endpoints/clients.py
+++ b/backend/src/presentation/api/v1/endpoints/clients.py
@@ -1,0 +1,144 @@
+"""API endpoints for managing clients."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from src.application.dtos.client_dto import (
+    ClientCreateDTO,
+    ClientListResponseDTO,
+    ClientResponseDTO,
+    ClientUpdateDTO,
+)
+from src.application.services.client_service import ClientService
+from src.domain.entities.user import User
+from src.infrastructure.container import get_client_repository
+from src.infrastructure.repositories.client_repository import ClientRepository
+from src.presentation.dependencies.auth import get_current_active_user
+
+router = APIRouter()
+
+
+async def get_client_service(
+    client_repository: ClientRepository = Depends(get_client_repository),
+) -> ClientService:
+    """Resolve the client service with Mongo repository implementation."""
+
+    return ClientService(client_repository)
+
+
+@router.get(
+    "/",
+    response_model=ClientListResponseDTO,
+    summary="Listar clientes",
+    description="Retorna a lista de clientes com suporte a filtro por nome ou CPF.",
+)
+async def list_clients(
+    search: str | None = Query(
+        default=None, description="Filtro por nome, e-mail ou CPF"
+    ),
+    page: int = Query(1, ge=1, description="Página atual"),
+    page_size: int = Query(20, ge=1, le=100, description="Itens por página"),
+    service: ClientService = Depends(get_client_service),
+    current_user: User = Depends(get_current_active_user),
+) -> ClientListResponseDTO:
+    """List clients applying optional search and pagination."""
+
+    result = await service.list_clients(search=search, page=page, page_size=page_size)
+
+    return ClientListResponseDTO(
+        success=result["success"],
+        message=result.get("message"),
+        clients=result["clients"],
+        pagination=result["pagination"],
+    )
+
+
+@router.post(
+    "/",
+    response_model=ClientResponseDTO,
+    status_code=status.HTTP_201_CREATED,
+    summary="Criar cliente",
+    description="Cria um novo cliente manualmente a partir da tela de gestão.",
+)
+async def create_client(
+    client_data: ClientCreateDTO,
+    service: ClientService = Depends(get_client_service),
+    current_user: User = Depends(get_current_active_user),
+) -> ClientResponseDTO:
+    """Create a client manually."""
+
+    result = await service.create_client(client_data)
+    if not result["success"]:
+        error_code = result.get("error_code")
+        if error_code == "duplicate":
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT, detail=result["message"]
+            )
+        if error_code == "validation":
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST, detail=result["message"]
+            )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=result.get("message", "Erro interno"),
+        )
+
+    return ClientResponseDTO(
+        success=True,
+        message=result.get("message"),
+        client=result["client"],
+    )
+
+
+@router.get(
+    "/{client_id}",
+    response_model=ClientResponseDTO,
+    summary="Detalhar cliente",
+    description="Retorna os dados completos de um cliente, incluindo histórico.",
+)
+async def get_client(
+    client_id: str,
+    service: ClientService = Depends(get_client_service),
+    current_user: User = Depends(get_current_active_user),
+) -> ClientResponseDTO:
+    """Retrieve a client by identifier."""
+
+    result = await service.get_client(client_id)
+    if not result["success"]:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=result["message"])
+
+    return ClientResponseDTO(success=True, client=result["client"])
+
+
+@router.put(
+    "/{client_id}",
+    response_model=ClientResponseDTO,
+    summary="Atualizar cliente",
+    description="Atualiza dados cadastrais de um cliente existente.",
+)
+async def update_client(
+    client_id: str,
+    payload: ClientUpdateDTO,
+    service: ClientService = Depends(get_client_service),
+    current_user: User = Depends(get_current_active_user),
+) -> ClientResponseDTO:
+    """Update an existing client."""
+
+    result = await service.update_client(client_id, payload)
+    if not result["success"]:
+        error_code = result.get("error_code")
+        if error_code == "not_found":
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=result["message"])
+        if error_code == "validation":
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=result["message"])
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=result.get("message", "Erro interno"),
+        )
+
+    return ClientResponseDTO(
+        success=True,
+        message=result.get("message"),
+        client=result["client"],
+    )

--- a/backend/src/presentation/api/v1/router.py
+++ b/backend/src/presentation/api/v1/router.py
@@ -14,6 +14,7 @@ from src.presentation.api.v1.endpoints import (
     appointments,
     auth,
     cars,
+    clients,
     collectors,
     drivers,
     logistics_packages,
@@ -42,6 +43,10 @@ api_v1_router.include_router(
 
 api_v1_router.include_router(
     appointments.router, prefix="/appointments", tags=["Appointments"]
+)
+
+api_v1_router.include_router(
+    clients.router, prefix="/clients", tags=["Clients"]
 )
 
 api_v1_router.include_router(
@@ -83,6 +88,7 @@ async def api_v1_root() -> dict[str, Any]:
             "auth": f"{settings.api_v1_prefix}/auth",
             "admin": f"{settings.api_v1_prefix}/admin",
             "appointments": f"{settings.api_v1_prefix}/appointments",
+            "clients": f"{settings.api_v1_prefix}/clients",
             "drivers": f"{settings.api_v1_prefix}/drivers",
             "collectors": f"{settings.api_v1_prefix}/collectors",
             "cars": f"{settings.api_v1_prefix}/cars",

--- a/backend/tests/test_appointment_api.py
+++ b/backend/tests/test_appointment_api.py
@@ -23,6 +23,9 @@ from src.presentation.dependencies.auth import (
 from src.presentation.dependencies.services import get_dashboard_analytics_service
 
 
+VALID_CPF = "52998224725"
+
+
 @pytest.fixture
 def active_user() -> User:
     """Authenticated user injected into route dependencies."""
@@ -76,7 +79,7 @@ def _build_response_dto() -> AppointmentResponseDTO:
         endereco_normalizado=None,
         documento_completo=None,
         documento_normalizado=None,
-        cpf=None,
+        cpf=VALID_CPF,
         rg=None,
         numero_convenio=None,
         nome_convenio=None,
@@ -96,6 +99,7 @@ def test_create_appointment_success(client: TestClient) -> None:
         "hora_agendamento": "09:00",
         "status": "Confirmado",
         "telefone": "11999988888",
+        "cpf": VALID_CPF,
     }
 
     service_mock = MagicMock()
@@ -143,6 +147,7 @@ def test_create_appointment_error_responses(
         "hora_agendamento": "09:00",
         "status": "Confirmado",
         "telefone": "11999988888",
+        "cpf": VALID_CPF,
     }
 
     service_mock = MagicMock()

--- a/backend/tests/test_client_api.py
+++ b/backend/tests/test_client_api.py
@@ -1,0 +1,216 @@
+"""API tests for client management endpoints."""
+
+from uuid import uuid4
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.application.dtos.appointment_dto import PaginationDTO
+from src.application.dtos.client_dto import (
+    ClientAppointmentHistoryDTO,
+    ClientDetailDTO,
+    ClientSummaryDTO,
+)
+from src.domain.entities.user import User
+from src.main import app
+from src.presentation.api.v1.endpoints.clients import get_client_service
+from src.presentation.dependencies.auth import (
+    get_current_active_user,
+    get_current_admin_user,
+)
+
+
+VALID_CPF = "52998224725"
+
+
+@pytest.fixture
+def active_user() -> User:
+    return User(
+        email="tester@example.com",
+        name="Tester",
+        password_hash="hashed",
+        is_admin=True,
+        is_active=True,
+    )
+
+
+@pytest.fixture
+def client(active_user: User) -> TestClient:
+    async def override_current_user() -> User:
+        return active_user
+
+    app.dependency_overrides[get_current_active_user] = override_current_user
+    app.dependency_overrides[get_current_admin_user] = override_current_user
+
+    try:
+        with TestClient(app) as test_client:
+            yield test_client
+    finally:
+        app.dependency_overrides.pop(get_current_active_user, None)
+        app.dependency_overrides.pop(get_current_admin_user, None)
+
+
+def _build_summary() -> ClientSummaryDTO:
+    return ClientSummaryDTO(
+        id=uuid4(),
+        nome_completo="Maria Cliente",
+        cpf=VALID_CPF,
+        cpf_formatado="529.982.247-25",
+        telefone="11999999999",
+        email="maria@example.com",
+        total_agendamentos=1,
+        ultima_data_agendamento=None,
+        ultima_unidade=None,
+        ultima_marca=None,
+        ultima_consulta_tipo=None,
+        ultima_consulta_status=None,
+        created_at=datetime.utcnow(),
+        updated_at=None,
+    )
+
+
+from datetime import datetime
+
+
+def _build_detail() -> ClientDetailDTO:
+    summary = _build_summary()
+    history = [
+        ClientAppointmentHistoryDTO(
+            appointment_id=uuid4(),
+            nome_marca="Marca",
+            nome_unidade="Unidade",
+            nome_paciente="Maria Cliente",
+            data_agendamento=datetime(2025, 6, 1, 9, 0),
+            hora_agendamento="09:00",
+            status="Confirmado",
+            tipo_consulta="Consulta",
+            observacoes=None,
+            created_at=datetime.utcnow(),
+        )
+    ]
+    return ClientDetailDTO(**summary.model_dump(), appointment_history=history)
+
+
+def test_list_clients_success(client: TestClient) -> None:
+    service_mock = MagicMock()
+    service_mock.list_clients = AsyncMock(
+        return_value={
+            "success": True,
+            "clients": [_build_summary()],
+            "pagination": PaginationDTO(
+                page=1,
+                page_size=20,
+                total_items=1,
+                total_pages=1,
+                has_next=False,
+                has_previous=False,
+            ),
+        }
+    )
+
+    async def override_service() -> MagicMock:
+        return service_mock
+
+    app.dependency_overrides[get_client_service] = override_service
+    try:
+        response = client.get("/api/v1/clients")
+    finally:
+        app.dependency_overrides.pop(get_client_service, None)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["success"] is True
+    assert len(payload["clients"]) == 1
+
+
+def test_create_client_success(client: TestClient) -> None:
+    service_mock = MagicMock()
+    detail = _build_detail()
+    service_mock.create_client = AsyncMock(
+        return_value={"success": True, "message": "Cliente criado", "client": detail}
+    )
+
+    async def override_service() -> MagicMock:
+        return service_mock
+
+    app.dependency_overrides[get_client_service] = override_service
+    payload = {"nome_completo": "Maria Cliente", "cpf": VALID_CPF}
+    try:
+        response = client.post("/api/v1/clients", json=payload)
+    finally:
+        app.dependency_overrides.pop(get_client_service, None)
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["success"] is True
+    assert body["client"]["nome_completo"] == "Maria Cliente"
+
+
+@pytest.mark.parametrize(
+    "error_code,status_code",
+    [("duplicate", 409), ("validation", 400), ("internal", 500)],
+)
+def test_create_client_error_mapping(client: TestClient, error_code: str, status_code: int) -> None:
+    service_mock = MagicMock()
+    service_mock.create_client = AsyncMock(
+        return_value={"success": False, "message": "Erro", "error_code": error_code}
+    )
+
+    async def override_service() -> MagicMock:
+        return service_mock
+
+    app.dependency_overrides[get_client_service] = override_service
+    try:
+        response = client.post(
+            "/api/v1/clients",
+            json={"nome_completo": "Maria Cliente", "cpf": VALID_CPF},
+        )
+    finally:
+        app.dependency_overrides.pop(get_client_service, None)
+
+    assert response.status_code == status_code
+    body = response.json()
+    assert body["message"] == "Erro"
+
+
+def test_get_client_not_found(client: TestClient) -> None:
+    service_mock = MagicMock()
+    service_mock.get_client = AsyncMock(
+        return_value={"success": False, "message": "Cliente não encontrado", "error_code": "not_found"}
+    )
+
+    async def override_service() -> MagicMock:
+        return service_mock
+
+    app.dependency_overrides[get_client_service] = override_service
+    try:
+        response = client.get(f"/api/v1/clients/{uuid4()}")
+    finally:
+        app.dependency_overrides.pop(get_client_service, None)
+
+    assert response.status_code == 404
+    assert response.json()["message"] == "Cliente não encontrado"
+
+
+def test_update_client_success(client: TestClient) -> None:
+    service_mock = MagicMock()
+    detail = _build_detail()
+    service_mock.update_client = AsyncMock(
+        return_value={"success": True, "message": "Atualizado", "client": detail}
+    )
+
+    async def override_service() -> MagicMock:
+        return service_mock
+
+    app.dependency_overrides[get_client_service] = override_service
+    client_id = str(uuid4())
+    try:
+        response = client.put(
+            f"/api/v1/clients/{client_id}", json={"telefone": "11999999999"}
+        )
+    finally:
+        app.dependency_overrides.pop(get_client_service, None)
+
+    assert response.status_code == 200
+    assert response.json()["success"] is True

--- a/backend/tests/test_client_service.py
+++ b/backend/tests/test_client_service.py
@@ -1,0 +1,181 @@
+"""Tests for the client service covering manual and automatic flows."""
+
+from datetime import datetime
+from typing import Dict, List, Optional
+
+import pytest
+
+from src.application.dtos.client_dto import ClientCreateDTO, ClientUpdateDTO
+from src.application.services.client_service import ClientService
+from src.domain.entities.appointment import Appointment
+from src.domain.entities.client import Client
+from src.domain.repositories.client_repository_interface import ClientRepositoryInterface
+
+
+VALID_CPF = "52998224725"
+SECOND_VALID_CPF = "48449253691"
+
+
+class InMemoryClientRepository(ClientRepositoryInterface):
+    """Simple in-memory repository used for unit tests."""
+
+    def __init__(self) -> None:
+        self.storage: Dict[str, Client] = {}
+
+    async def create(self, client: Client) -> Client:
+        self.storage[str(client.id)] = client
+        return client
+
+    async def update(self, client: Client) -> Client:
+        self.storage[str(client.id)] = client
+        return client
+
+    async def find_by_id(self, client_id: str) -> Optional[Client]:
+        return self.storage.get(client_id)
+
+    async def find_by_cpf(self, cpf: str) -> Optional[Client]:
+        for client in self.storage.values():
+            if client.cpf == cpf:
+                return client
+        return None
+
+    async def find_by_filters(
+        self, search: Optional[str], skip: int = 0, limit: int = 50
+    ) -> List[Client]:
+        entries = list(self.storage.values())
+        if search:
+            lowered = search.lower()
+            entries = [
+                client
+                for client in entries
+                if lowered in client.nome_completo.lower()
+                or lowered in (client.email or '').lower()
+                or lowered in client.cpf
+            ]
+        return entries[skip : skip + limit]
+
+    async def count(self, search: Optional[str] = None) -> int:
+        results = await self.find_by_filters(search)
+        return len(results)
+
+    async def ensure_indexes(self) -> None:  # pragma: no cover - not needed for in-memory
+        return None
+
+
+@pytest.mark.asyncio
+async def test_create_client_success() -> None:
+    repository = InMemoryClientRepository()
+    service = ClientService(repository)
+
+    dto = ClientCreateDTO(nome_completo="Maria Silva", cpf=VALID_CPF)
+    result = await service.create_client(dto)
+
+    assert result["success"] is True
+    stored = await repository.find_by_cpf(VALID_CPF)
+    assert stored is not None
+    assert stored.nome_completo == "Maria Silva"
+
+
+@pytest.mark.asyncio
+async def test_create_client_duplicate_cpf() -> None:
+    repository = InMemoryClientRepository()
+    service = ClientService(repository)
+
+    dto = ClientCreateDTO(nome_completo="Maria Silva", cpf=VALID_CPF)
+    await service.create_client(dto)
+
+    duplicate = await service.create_client(dto)
+    assert duplicate["success"] is False
+    assert duplicate["error_code"] == "duplicate"
+
+
+@pytest.mark.asyncio
+async def test_sync_from_appointment_creates_client() -> None:
+    repository = InMemoryClientRepository()
+    service = ClientService(repository)
+
+    appointment = Appointment(
+        nome_marca="Marca",
+        nome_unidade="Unidade",
+        nome_paciente="Ana Paciente",
+        data_agendamento=datetime(2025, 5, 10, 9, 0),
+        hora_agendamento="09:00",
+        status="Confirmado",
+        telefone="11999999999",
+        cpf=VALID_CPF,
+    )
+
+    await service.sync_from_appointment(appointment)
+
+    stored = await repository.find_by_cpf(VALID_CPF)
+    assert stored is not None
+    assert stored.total_agendamentos == 1
+    assert stored.appointment_history[0].nome_paciente == "Ana Paciente"
+
+
+@pytest.mark.asyncio
+async def test_sync_from_appointment_updates_existing_client() -> None:
+    repository = InMemoryClientRepository()
+    service = ClientService(repository)
+
+    dto = ClientCreateDTO(nome_completo="Ana Paciente", cpf=VALID_CPF)
+    create_result = await service.create_client(dto)
+    assert create_result["success"] is True
+
+    appointment = Appointment(
+        nome_marca="Outra Marca",
+        nome_unidade="Outra Unidade",
+        nome_paciente="Ana Paciente",
+        data_agendamento=datetime(2025, 6, 15, 10, 30),
+        hora_agendamento="10:30",
+        status="Agendado",
+        telefone="1188887777",
+        cpf=VALID_CPF,
+        observacoes="Consulta de retorno",
+    )
+
+    await service.sync_from_appointment(appointment)
+
+    stored = await repository.find_by_cpf(VALID_CPF)
+    assert stored is not None
+    assert stored.total_agendamentos == 1
+    assert stored.telefone == "1188887777"
+    assert stored.ultima_marca == "Outra Marca"
+    assert stored.appointment_history[0].observacoes == "Consulta de retorno"
+
+
+@pytest.mark.asyncio
+async def test_update_client_success() -> None:
+    repository = InMemoryClientRepository()
+    service = ClientService(repository)
+
+    create_result = await service.create_client(
+        ClientCreateDTO(nome_completo="João Cliente", cpf=VALID_CPF)
+    )
+    client_id = str(create_result["client"].id)
+
+    update_result = await service.update_client(
+        client_id,
+        ClientUpdateDTO(email="joao@example.com", telefone="1191112222"),
+    )
+
+    assert update_result["success"] is True
+    stored = await repository.find_by_id(client_id)
+    assert stored is not None
+    assert stored.email == "joao@example.com"
+    assert stored.telefone == "1191112222"
+
+
+@pytest.mark.asyncio
+async def test_list_clients_with_search() -> None:
+    repository = InMemoryClientRepository()
+    service = ClientService(repository)
+
+    await service.create_client(ClientCreateDTO(nome_completo="Ana Maria", cpf="39053344705"))
+    await service.create_client(ClientCreateDTO(nome_completo="Bruno Costa", cpf=SECOND_VALID_CPF))
+
+    result = await service.list_clients(search="Bruno", page=1, page_size=10)
+
+    assert result["success"] is True
+    assert len(result["clients"]) == 1
+    assert result["clients"][0].nome_completo == "Bruno Costa"

--- a/frontend/src/components/AppointmentFormModal.tsx
+++ b/frontend/src/components/AppointmentFormModal.tsx
@@ -11,6 +11,7 @@ import { APPOINTMENT_STATUS_OPTIONS } from '../utils/appointmentViewModel';
 import type { Tag } from '../types/tag';
 import type { LogisticsPackage } from '../types/logistics-package';
 import { TagSelector } from './tags/TagSelector';
+import { isValidCpf, normalizeCpf } from '../utils/cpf';
 
 interface AppointmentFormModalProps {
   isOpen: boolean;
@@ -75,6 +76,11 @@ const formSchema = z.object({
       const digits = value.replace(/\D/g, '');
       return digits.length === 10 || digits.length === 11;
     }, 'Telefone deve conter 10 ou 11 dígitos'),
+  cpf: z
+    .string()
+    .trim()
+    .min(1, 'Informe o CPF do paciente')
+    .refine((value) => isValidCpf(value), 'CPF inválido. Verifique os dígitos.'),
   carro: z.string().trim().default(''),
   logistics_package_id: z.string().trim().default(''),
   observacoes: z.string().trim().default(''),
@@ -145,6 +151,7 @@ export function AppointmentFormModal({
       cip: '',
       status: defaultStatus,
       telefone: '',
+      cpf: '',
       carro: '',
       logistics_package_id: '',
       observacoes: '',
@@ -228,6 +235,7 @@ export function AppointmentFormModal({
     }
 
     const phoneDigits = values.telefone.replace(/\D/g, '');
+    const cpfDigits = normalizeCpf(values.cpf);
 
     const payload: AppointmentCreateRequest = {
       nome_marca: values.nome_marca.trim(),
@@ -237,6 +245,7 @@ export function AppointmentFormModal({
       cip: values.cip.trim() || undefined,
       status: values.status || DEFAULT_STATUS,
       telefone: phoneDigits,
+      cpf: cpfDigits,
       carro: values.carro.trim() || undefined,
       observacoes: values.observacoes.trim() || undefined,
       driver_id: values.driver_id || undefined,
@@ -401,6 +410,19 @@ export function AppointmentFormModal({
             />
             {errors.telefone && (
               <p className="mt-1 text-sm text-red-600">{errors.telefone.message}</p>
+            )}
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">CPF *</label>
+            <input
+              type="text"
+              {...register('cpf')}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+              placeholder="00000000000"
+              disabled={isSubmitting}
+            />
+            {errors.cpf && (
+              <p className="mt-1 text-sm text-red-600">{errors.cpf.message}</p>
             )}
           </div>
           {logisticsPackages.length > 0 && (

--- a/frontend/src/components/clients/ClientFormModal.tsx
+++ b/frontend/src/components/clients/ClientFormModal.tsx
@@ -1,0 +1,245 @@
+import { useEffect, useMemo } from 'react';
+import { useForm, type SubmitHandler } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+
+import { Modal } from '../ui/Modal';
+import type { ClientCreateRequest, ClientDetail, ClientUpdateRequest } from '../../types/client';
+import { formatCpf, isValidCpf, normalizeCpf } from '../../utils/cpf';
+
+const emptyStringSchema = z.string().trim().length(0);
+
+const formSchema = z.object({
+  nome_completo: z.string().trim().min(1, 'Informe o nome completo'),
+  cpf: z
+    .string()
+    .trim()
+    .min(1, 'Informe o CPF')
+    .refine((value) => isValidCpf(value), 'CPF inválido. Verifique os dígitos.'),
+  telefone: z.string().trim().optional(),
+  email: z
+    .union([emptyStringSchema, z.string().trim().email('E-mail inválido')])
+    .optional(),
+  observacoes: z.string().trim().optional(),
+  numero_convenio: z.string().trim().optional(),
+  nome_convenio: z.string().trim().optional(),
+  carteira_convenio: z.string().trim().optional(),
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+interface ClientFormModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  mode: 'create' | 'edit';
+  onSubmit: (payload: ClientCreateRequest | ClientUpdateRequest) => Promise<void> | void;
+  isSubmitting?: boolean;
+  initialData?: ClientDetail | null;
+}
+
+const sanitizeOptional = (value?: string | null): string | undefined => {
+  if (!value) {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+};
+
+const normalizePhone = (value?: string | null): string | undefined => {
+  if (!value) {
+    return undefined;
+  }
+  const digits = value.replace(/\D/g, '');
+  return digits ? digits : undefined;
+};
+
+export const ClientFormModal: React.FC<ClientFormModalProps> = ({
+  isOpen,
+  onClose,
+  mode,
+  onSubmit,
+  isSubmitting = false,
+  initialData,
+}) => {
+  const defaults = useMemo<FormValues>(() => {
+    return {
+      nome_completo: initialData?.nome_completo ?? '',
+      cpf: initialData?.cpf ? formatCpf(initialData.cpf) : '',
+      telefone: initialData?.telefone ?? '',
+      email: initialData?.email ?? '',
+      observacoes: initialData?.observacoes ?? '',
+      numero_convenio: initialData?.numero_convenio ?? '',
+      nome_convenio: initialData?.nome_convenio ?? '',
+      carteira_convenio: initialData?.carteira_convenio ?? '',
+    } as FormValues;
+  }, [initialData]);
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: defaults,
+  });
+
+  useEffect(() => {
+    if (isOpen) {
+      reset(defaults);
+    }
+  }, [isOpen, defaults, reset]);
+
+  const onSubmitForm: SubmitHandler<FormValues> = async (values) => {
+    if (mode === 'create') {
+      const payload: ClientCreateRequest = {
+        nome_completo: values.nome_completo.trim(),
+        cpf: normalizeCpf(values.cpf),
+        telefone: normalizePhone(values.telefone),
+        email: sanitizeOptional(values.email),
+        observacoes: sanitizeOptional(values.observacoes),
+        numero_convenio: sanitizeOptional(values.numero_convenio),
+        nome_convenio: sanitizeOptional(values.nome_convenio),
+        carteira_convenio: sanitizeOptional(values.carteira_convenio),
+      };
+
+      await onSubmit(payload);
+      return;
+    }
+
+    const updatePayload: ClientUpdateRequest = {
+      nome_completo: values.nome_completo.trim(),
+      telefone: normalizePhone(values.telefone),
+      email: sanitizeOptional(values.email),
+      observacoes: sanitizeOptional(values.observacoes),
+      numero_convenio: sanitizeOptional(values.numero_convenio),
+      nome_convenio: sanitizeOptional(values.nome_convenio),
+      carteira_convenio: sanitizeOptional(values.carteira_convenio),
+    };
+
+    await onSubmit(updatePayload);
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={mode === 'create' ? 'Cadastrar cliente' : 'Editar cliente'}
+      size="lg"
+    >
+      <form className="space-y-5" onSubmit={handleSubmit(onSubmitForm)}>
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Nome completo *</label>
+            <input
+              type="text"
+              {...register('nome_completo')}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+              disabled={isSubmitting}
+            />
+            {errors.nome_completo && (
+              <p className="mt-1 text-sm text-red-600">{errors.nome_completo.message}</p>
+            )}
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">CPF *</label>
+            <input
+              type="text"
+              {...register('cpf')}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+              disabled={mode === 'edit' || isSubmitting}
+            />
+            {errors.cpf && (
+              <p className="mt-1 text-sm text-red-600">{errors.cpf.message}</p>
+            )}
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Telefone</label>
+            <input
+              type="tel"
+              {...register('telefone')}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+              placeholder="11999988888"
+              disabled={isSubmitting}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">E-mail</label>
+            <input
+              type="email"
+              {...register('email')}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+              placeholder="cliente@exemplo.com"
+              disabled={isSubmitting}
+            />
+            {errors.email && (
+              <p className="mt-1 text-sm text-red-600">{errors.email.message}</p>
+            )}
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Nome do convênio</label>
+            <input
+              type="text"
+              {...register('nome_convenio')}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+              disabled={isSubmitting}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Número do convênio</label>
+            <input
+              type="text"
+              {...register('numero_convenio')}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+              disabled={isSubmitting}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Carteira do convênio</label>
+            <input
+              type="text"
+              {...register('carteira_convenio')}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+              disabled={isSubmitting}
+            />
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700">Observações</label>
+          <textarea
+            rows={4}
+            {...register('observacoes')}
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+            placeholder="Informações adicionais relevantes"
+            disabled={isSubmitting}
+          />
+        </div>
+
+        <div className="flex justify-end gap-3 border-t border-gray-200 pt-4">
+          <button
+            type="button"
+            onClick={onClose}
+            className="inline-flex justify-center rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+            disabled={isSubmitting}
+          >
+            Cancelar
+          </button>
+          <button
+            type="submit"
+            className="inline-flex justify-center rounded-md border border-transparent px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-60"
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? 'Salvando...' : 'Salvar'}
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+};

--- a/frontend/src/config/appRoutes.tsx
+++ b/frontend/src/config/appRoutes.tsx
@@ -9,6 +9,7 @@ import { DriversPage } from '../pages/DriversPage';
 import { LogisticsPackagesPage } from '../pages/LogisticsPackagesPage';
 import { TagsPage } from '../pages/TagsPage';
 import { UsersPage } from '../pages/UsersPage';
+import { ClientsPage } from '../pages/ClientsPage';
 
 export interface AppRoute {
   id: string;
@@ -39,6 +40,13 @@ export const APP_ROUTES: AppRoute[] = [
     Component: AppointmentsPage,
     allowedRoles: [ROLES.ADMIN, ROLES.COLABORADOR],
     breadcrumb: ['Operação', 'Agendamentos'],
+  },
+  {
+    id: 'clients',
+    path: '/cadastros/clientes',
+    Component: ClientsPage,
+    allowedRoles: [ROLES.ADMIN, ROLES.COLABORADOR],
+    breadcrumb: ['Cadastros', 'Clientes'],
   },
   {
     id: 'drivers',

--- a/frontend/src/config/navigationConfig.tsx
+++ b/frontend/src/config/navigationConfig.tsx
@@ -50,6 +50,15 @@ export const NAVIGATION_ITEMS: NavigationItem[] = [
     allowedRoles: [ROLES.ADMIN, ROLES.COLABORADOR],
   },
   {
+    id: 'clientes',
+    label: 'Clientes',
+    description: 'Cadastre e gerencie pacientes',
+    group: 'cadastros',
+    icon: UsersIcon,
+    to: '/cadastros/clientes',
+    allowedRoles: [ROLES.ADMIN, ROLES.COLABORADOR],
+  },
+  {
     id: 'motoristas',
     label: 'Motoristas',
     description: 'Cadastre e gerencie motoristas',

--- a/frontend/src/pages/ClientsPage.tsx
+++ b/frontend/src/pages/ClientsPage.tsx
@@ -1,0 +1,394 @@
+import { isAxiosError } from 'axios';
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  keepPreviousData,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
+
+import { clientAPI } from '../services/api';
+import { ClientFormModal } from '../components/clients/ClientFormModal';
+import { ToastContainer } from '../components/ui/Toast';
+import { useToast } from '../hooks/useToast';
+import type {
+  ClientCreateRequest,
+  ClientDetail,
+  ClientListResponse,
+  ClientResponse,
+  ClientSummary,
+  ClientUpdateRequest,
+} from '../types/client';
+import { formatCpf } from '../utils/cpf';
+
+const PAGE_SIZE = 20;
+
+const formatDateTime = (value?: string | null): string => {
+  if (!value) {
+    return '—';
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '—';
+  }
+  return date.toLocaleString('pt-BR', {
+    dateStyle: 'short',
+    timeStyle: 'short',
+  });
+};
+
+export const ClientsPage: React.FC = () => {
+  const queryClient = useQueryClient();
+  const { toasts, success: showSuccess, error: showError, removeToast } = useToast();
+
+  const [search, setSearch] = useState('');
+  const [page, setPage] = useState(1);
+  const [selectedClientId, setSelectedClientId] = useState<string | null>(null);
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+
+  const listQuery = useQuery<ClientListResponse>({
+    queryKey: ['clients', { search, page }],
+    queryFn: () =>
+      clientAPI.listClients({
+        search: search.trim() || undefined,
+        page,
+        page_size: PAGE_SIZE,
+      }),
+    placeholderData: keepPreviousData,
+  });
+
+  const clients: ClientSummary[] = listQuery.data?.clients ?? [];
+  const pagination = listQuery.data?.pagination;
+
+  useEffect(() => {
+    if (clients.length === 0) {
+      return;
+    }
+
+    if (!selectedClientId || !clients.some((client) => client.id === selectedClientId)) {
+      setSelectedClientId(clients[0].id);
+    }
+  }, [clients, selectedClientId]);
+
+  const detailQuery = useQuery<ClientResponse>({
+    queryKey: ['clients', 'detail', selectedClientId],
+    queryFn: () => clientAPI.getClient(selectedClientId!),
+    enabled: Boolean(selectedClientId),
+  });
+
+  const createClientMutation = useMutation<
+    ClientResponse,
+    unknown,
+    ClientCreateRequest
+  >({
+    mutationFn: (payload: ClientCreateRequest) => clientAPI.createClient(payload),
+    onSuccess: (response) => {
+      showSuccess(response.message ?? 'Cliente cadastrado com sucesso.');
+      setIsCreateModalOpen(false);
+      queryClient.invalidateQueries({ queryKey: ['clients'] });
+      if (response.client?.id) {
+        setSelectedClientId(response.client.id);
+        queryClient.invalidateQueries({ queryKey: ['clients', 'detail', response.client.id] });
+      }
+    },
+    onError: (error) => {
+      if (isAxiosError(error)) {
+        const message = error.response?.data?.message ?? 'Não foi possível cadastrar o cliente.';
+        showError(message);
+      } else {
+        showError('Não foi possível cadastrar o cliente.');
+      }
+    },
+  });
+
+  const updateClientMutation = useMutation<
+    ClientResponse,
+    unknown,
+    { id: string; payload: ClientUpdateRequest }
+  >({
+    mutationFn: ({ id, payload }: { id: string; payload: ClientUpdateRequest }) =>
+      clientAPI.updateClient(id, payload),
+    onSuccess: (response, variables) => {
+      showSuccess(response.message ?? 'Cliente atualizado com sucesso.');
+      setIsEditModalOpen(false);
+      queryClient.invalidateQueries({ queryKey: ['clients'] });
+      queryClient.invalidateQueries({ queryKey: ['clients', 'detail', variables.id] });
+    },
+    onError: (error) => {
+      if (isAxiosError(error)) {
+        const message = error.response?.data?.message ?? 'Não foi possível atualizar o cliente.';
+        showError(message);
+      } else {
+        showError('Não foi possível atualizar o cliente.');
+      }
+    },
+  });
+
+  const selectedClient: ClientDetail | undefined = detailQuery.data?.client;
+
+  const handleCreateSubmit = (payload: ClientCreateRequest | ClientUpdateRequest) => {
+    createClientMutation.mutate(payload as ClientCreateRequest);
+  };
+
+  const handleUpdateSubmit = (payload: ClientCreateRequest | ClientUpdateRequest) => {
+    if (!selectedClientId) {
+      return;
+    }
+    updateClientMutation.mutate({ id: selectedClientId, payload: payload as ClientUpdateRequest });
+  };
+
+  const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setSearch(event.target.value);
+    setPage(1);
+  };
+
+  const isListLoading = listQuery.isLoading;
+  const isDetailLoading = detailQuery.isLoading;
+
+  const history = useMemo(() => {
+    if (!selectedClient) {
+      return [];
+    }
+
+    return [...selectedClient.appointment_history].sort((a, b) => {
+      const dateA = a.data_agendamento ?? a.created_at;
+      const dateB = b.data_agendamento ?? b.created_at;
+      return dateB.localeCompare(dateA);
+    });
+  }, [selectedClient]);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900">Clientes</h1>
+          <p className="mt-1 text-sm text-gray-600">Gerencie os dados dos pacientes e acompanhe o histórico de agendamentos associados.</p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setIsCreateModalOpen(true)}
+          className="inline-flex items-center rounded-md border border-transparent bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+        >
+          Novo cliente
+        </button>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-12">
+        <div className="lg:col-span-7">
+          <div className="rounded-lg border border-gray-200 bg-white shadow-sm">
+            <div className="flex flex-col gap-3 border-b border-gray-200 p-4 md:flex-row md:items-center md:justify-between">
+              <div className="flex-1">
+                <label className="block text-sm font-medium text-gray-700" htmlFor="client-search">
+                  Buscar clientes
+                </label>
+                <input
+                  id="client-search"
+                  type="text"
+                  value={search}
+                  onChange={handleSearchChange}
+                  placeholder="Busque por nome, e-mail ou CPF"
+                  className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+                />
+              </div>
+              <div className="text-sm text-gray-500">
+                {pagination ? `Página ${pagination.page} de ${pagination.total_pages}` : '—'}
+              </div>
+            </div>
+
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-gray-200">
+                <thead className="bg-gray-50">
+                  <tr>
+                    <th scope="col" className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                      Cliente
+                    </th>
+                    <th scope="col" className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                      CPF
+                    </th>
+                    <th scope="col" className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                      Último agendamento
+                    </th>
+                    <th scope="col" className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                      Total
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-200 bg-white">
+                  {isListLoading && (
+                    <tr>
+                      <td colSpan={4} className="px-4 py-6 text-center text-sm text-gray-500">
+                        Carregando clientes...
+                      </td>
+                    </tr>
+                  )}
+                  {!isListLoading && clients.length === 0 && (
+                    <tr>
+                      <td colSpan={4} className="px-4 py-6 text-center text-sm text-gray-500">
+                        Nenhum cliente encontrado.
+                      </td>
+                    </tr>
+                  )}
+                  {!isListLoading &&
+                    clients.map((client) => {
+                      const isSelected = client.id === selectedClientId;
+                      return (
+                        <tr
+                          key={client.id}
+                          className={`cursor-pointer transition hover:bg-blue-50 ${isSelected ? 'bg-blue-50' : ''}`}
+                          onClick={() => setSelectedClientId(client.id)}
+                        >
+                          <td className="px-4 py-3">
+                            <div className="text-sm font-medium text-gray-900">{client.nome_completo}</div>
+                            {client.email && <div className="text-xs text-gray-500">{client.email}</div>}
+                          </td>
+                          <td className="px-4 py-3 text-sm text-gray-700">{client.cpf_formatado ?? formatCpf(client.cpf)}</td>
+                          <td className="px-4 py-3 text-sm text-gray-700">{formatDateTime(client.ultima_data_agendamento)}</td>
+                          <td className="px-4 py-3 text-sm text-gray-700">{client.total_agendamentos}</td>
+                        </tr>
+                      );
+                    })}
+                </tbody>
+              </table>
+            </div>
+
+            {pagination && (
+              <div className="flex items-center justify-between border-t border-gray-200 px-4 py-3 text-sm text-gray-600">
+                <button
+                  type="button"
+                  onClick={() => setPage((current) => Math.max(1, current - 1))}
+                  disabled={!pagination.has_previous}
+                  className="inline-flex items-center rounded-md border border-gray-300 bg-white px-3 py-1 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  Anterior
+                </button>
+                <span>
+                  Mostrando {clients.length} de {pagination.total_items} clientes
+                </span>
+                <button
+                  type="button"
+                  onClick={() => setPage((current) => current + 1)}
+                  disabled={!pagination.has_next}
+                  className="inline-flex items-center rounded-md border border-gray-300 bg-white px-3 py-1 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  Próxima
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="lg:col-span-5">
+          <div className="rounded-lg border border-gray-200 bg-white shadow-sm">
+            <div className="flex items-center justify-between border-b border-gray-200 px-4 py-3">
+              <div>
+                <h2 className="text-lg font-semibold text-gray-900">Detalhes do cliente</h2>
+                {selectedClient && (
+                  <p className="text-sm text-gray-500">CPF: {formatCpf(selectedClient.cpf)}</p>
+                )}
+              </div>
+              <button
+                type="button"
+                onClick={() => setIsEditModalOpen(true)}
+                disabled={!selectedClient}
+                className="inline-flex items-center rounded-md border border-transparent bg-gray-100 px-3 py-1.5 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-200 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Editar
+              </button>
+            </div>
+
+            <div className="space-y-4 px-4 py-4 text-sm text-gray-700">
+              {isDetailLoading && <p>Carregando detalhes...</p>}
+              {!isDetailLoading && selectedClient && (
+                <>
+                  <div>
+                    <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-500">Informações de contato</h3>
+                    <dl className="mt-1 grid grid-cols-1 gap-2 sm:grid-cols-2">
+                      <div>
+                        <dt className="text-xs text-gray-500">Telefone</dt>
+                        <dd className="text-sm text-gray-900">{selectedClient.telefone ?? '—'}</dd>
+                      </div>
+                      <div>
+                        <dt className="text-xs text-gray-500">E-mail</dt>
+                        <dd className="text-sm text-gray-900">{selectedClient.email ?? '—'}</dd>
+                      </div>
+                    </dl>
+                  </div>
+
+                  <div>
+                    <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-500">Dados de convênio</h3>
+                    <dl className="mt-1 grid grid-cols-1 gap-2 sm:grid-cols-2">
+                      <div>
+                        <dt className="text-xs text-gray-500">Nome do convênio</dt>
+                        <dd className="text-sm text-gray-900">{selectedClient.nome_convenio ?? '—'}</dd>
+                      </div>
+                      <div>
+                        <dt className="text-xs text-gray-500">Número do convênio</dt>
+                        <dd className="text-sm text-gray-900">{selectedClient.numero_convenio ?? '—'}</dd>
+                      </div>
+                      <div>
+                        <dt className="text-xs text-gray-500">Carteira</dt>
+                        <dd className="text-sm text-gray-900">{selectedClient.carteira_convenio ?? '—'}</dd>
+                      </div>
+                    </dl>
+                  </div>
+
+                  <div>
+                    <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-500">Observações</h3>
+                    <p className="mt-1 text-sm text-gray-900">{selectedClient.observacoes || 'Nenhuma observação registrada.'}</p>
+                  </div>
+
+                  <div>
+                    <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-500">Histórico de agendamentos</h3>
+                    {history.length === 0 ? (
+                      <p className="mt-1 text-sm text-gray-500">Nenhum agendamento registrado para este cliente.</p>
+                    ) : (
+                      <ul className="mt-2 space-y-3">
+                        {history.map((entry) => (
+                          <li key={entry.appointment_id} className="rounded-md border border-gray-200 px-3 py-2">
+                            <div className="flex items-center justify-between text-sm text-gray-700">
+                              <span className="font-medium text-gray-900">
+                                {entry.nome_marca ?? 'Marca não informada'} • {entry.nome_unidade ?? 'Unidade não informada'}
+                              </span>
+                              <span>{formatDateTime(entry.data_agendamento ?? entry.created_at)}</span>
+                            </div>
+                            <div className="mt-1 text-xs text-gray-500">
+                              {entry.tipo_consulta && <span className="mr-2">{entry.tipo_consulta}</span>}
+                              {entry.status && <span className="uppercase tracking-wide">{entry.status}</span>}
+                            </div>
+                            {entry.observacoes && (
+                              <p className="mt-1 text-sm text-gray-700">{entry.observacoes}</p>
+                            )}
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <ClientFormModal
+        isOpen={isCreateModalOpen}
+        onClose={() => setIsCreateModalOpen(false)}
+        mode="create"
+        onSubmit={handleCreateSubmit}
+        isSubmitting={createClientMutation.isPending}
+      />
+
+      <ClientFormModal
+        isOpen={isEditModalOpen}
+        onClose={() => setIsEditModalOpen(false)}
+        mode="edit"
+        initialData={selectedClient}
+        onSubmit={handleUpdateSubmit}
+        isSubmitting={updateClientMutation.isPending}
+      />
+
+      <ToastContainer toasts={toasts} onDismiss={removeToast} />
+    </div>
+  );
+};

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -58,6 +58,12 @@ import type {
     LogisticsPackageResponse,
     LogisticsPackageUpdateRequest,
 } from '../types/logistics-package';
+import type {
+    ClientCreateRequest,
+    ClientListResponse,
+    ClientResponse,
+    ClientUpdateRequest,
+} from '../types/client';
 
 const resolveApiBaseUrl = (): string => {
   if (typeof window !== 'undefined' && window.ENV?.API_URL) {
@@ -272,6 +278,59 @@ export const appointmentAPI = {
     );
 
     return response.data.data;
+  },
+};
+
+export const clientAPI = {
+  listClients: async ({
+    search,
+    page = 1,
+    page_size = 20,
+  }: {
+    search?: string;
+    page?: number;
+    page_size?: number;
+  }): Promise<ClientListResponse> => {
+    const params = new URLSearchParams();
+    params.append('page', page.toString());
+    params.append('page_size', page_size.toString());
+    if (search) {
+      params.append('search', search);
+    }
+
+    const response = await api.get<ClientListResponse>(
+      `/clients?${params.toString()}`,
+      { withCredentials: true }
+    );
+
+    return response.data;
+  },
+
+  getClient: async (clientId: string): Promise<ClientResponse> => {
+    const response = await api.get<ClientResponse>(`/clients/${clientId}`, {
+      withCredentials: true,
+    });
+
+    return response.data;
+  },
+
+  createClient: async (payload: ClientCreateRequest): Promise<ClientResponse> => {
+    const response = await api.post<ClientResponse>('/clients', payload, {
+      withCredentials: true,
+    });
+
+    return response.data;
+  },
+
+  updateClient: async (
+    clientId: string,
+    payload: ClientUpdateRequest
+  ): Promise<ClientResponse> => {
+    const response = await api.put<ClientResponse>(`/clients/${clientId}`, payload, {
+      withCredentials: true,
+    });
+
+    return response.data;
   },
 };
 

--- a/frontend/src/tests/smoke/appointments.test.tsx
+++ b/frontend/src/tests/smoke/appointments.test.tsx
@@ -85,6 +85,7 @@ describe('Appointments smoke tests', () => {
 
     assert.ok(markup.includes('Adicionar Agendamento'));
     assert.ok(markup.includes('name="nome_paciente"'));
+    assert.ok(markup.includes('name="cpf"'));
     assert.ok(markup.includes('Confirmado'));
   });
 

--- a/frontend/src/types/appointment.ts
+++ b/frontend/src/types/appointment.ts
@@ -73,6 +73,7 @@ export interface AppointmentCreateRequest {
   cip?: string;
   status?: string;
   telefone: string;
+  cpf: string;
   carro?: string;
   observacoes?: string;
   driver_id?: string;

--- a/frontend/src/types/client.ts
+++ b/frontend/src/types/client.ts
@@ -1,0 +1,73 @@
+import type { PaginationInfo } from './appointment';
+
+export interface ClientHistoryEntry {
+  appointment_id: string;
+  nome_marca?: string | null;
+  nome_unidade?: string | null;
+  nome_paciente?: string | null;
+  data_agendamento?: string | null;
+  hora_agendamento?: string | null;
+  status?: string | null;
+  tipo_consulta?: string | null;
+  observacoes?: string | null;
+  created_at: string;
+}
+
+export interface ClientSummary {
+  id: string;
+  nome_completo: string;
+  cpf: string;
+  cpf_formatado?: string | null;
+  telefone?: string | null;
+  email?: string | null;
+  total_agendamentos: number;
+  ultima_data_agendamento?: string | null;
+  ultima_unidade?: string | null;
+  ultima_marca?: string | null;
+  ultima_consulta_tipo?: string | null;
+  ultima_consulta_status?: string | null;
+  created_at: string;
+  updated_at?: string | null;
+}
+
+export interface ClientDetail extends ClientSummary {
+  observacoes?: string | null;
+  numero_convenio?: string | null;
+  nome_convenio?: string | null;
+  carteira_convenio?: string | null;
+  appointment_history: ClientHistoryEntry[];
+}
+
+export interface ClientCreateRequest {
+  nome_completo: string;
+  cpf: string;
+  telefone?: string;
+  email?: string;
+  observacoes?: string;
+  numero_convenio?: string;
+  nome_convenio?: string;
+  carteira_convenio?: string;
+}
+
+export interface ClientUpdateRequest {
+  nome_completo?: string;
+  telefone?: string;
+  email?: string;
+  observacoes?: string;
+  numero_convenio?: string;
+  nome_convenio?: string;
+  carteira_convenio?: string;
+}
+
+export interface ClientListResponse {
+  success: boolean;
+  message?: string;
+  clients: ClientSummary[];
+  pagination: PaginationInfo;
+}
+
+export interface ClientResponse {
+  success: boolean;
+  message?: string;
+  client: ClientDetail;
+}

--- a/frontend/src/utils/cpf.ts
+++ b/frontend/src/utils/cpf.ts
@@ -1,0 +1,51 @@
+export const onlyDigits = (value: string | null | undefined): string => {
+  if (!value) {
+    return '';
+  }
+  return value.replace(/\D/g, '');
+};
+
+export const normalizeCpf = (value: string | null | undefined): string => {
+  return onlyDigits(value);
+};
+
+export const isValidCpf = (value: string | null | undefined): boolean => {
+  const digits = onlyDigits(value);
+  if (digits.length !== 11) {
+    return false;
+  }
+
+  if (/^(\d)\1{10}$/.test(digits)) {
+    return false;
+  }
+
+  const calcCheckDigit = (sliceLength: number): number => {
+    let total = 0;
+    for (let index = 0; index < sliceLength; index += 1) {
+      total += parseInt(digits.charAt(index), 10) * (sliceLength + 1 - index);
+    }
+    const remainder = (total * 10) % 11;
+    return remainder === 10 ? 0 : remainder;
+  };
+
+  const firstCheck = calcCheckDigit(9);
+  const secondCheck = calcCheckDigit(10);
+
+  return (
+    firstCheck === parseInt(digits.charAt(9), 10) &&
+    secondCheck === parseInt(digits.charAt(10), 10)
+  );
+};
+
+export const formatCpf = (value: string | null | undefined): string => {
+  const digits = onlyDigits(value);
+  if (digits.length !== 11) {
+    return value?.trim() ?? '';
+  }
+
+  return `${digits.slice(0, 3)}.${digits.slice(3, 6)}.${digits.slice(6, 9)}-${digits.slice(9)}`;
+};
+
+export const maskCpf = (value: string | null | undefined): string => {
+  return formatCpf(value);
+};


### PR DESCRIPTION
## Summary
- add full client domain stack with DTOs, service, repository, and FastAPI endpoints for manual management and appointment sync
- require CPF during appointment creation/import and sync appointment data into client records
- build client management page with list/detail panes, modal forms, CPF utilities, and API client helpers

## Testing
- `poetry run pytest`
- `npm run lint` *(fails: existing lint violations in unrelated files)*
- `npm run test -- --watch=false` *(fails: esbuild lacks SVG loader configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d85f5b926083238fa90073bb435d8e