### PR TITLE
feat: implement mobile navigation drawer (Phase 1 - Mobile Responsiveness)

### DIFF
--- a/frontend/src/components/Breadcrumbs.tsx
+++ b/frontend/src/components/Breadcrumbs.tsx
@@ -16,21 +16,32 @@ export const Breadcrumbs: React.FC = () => {
     return null;
   }
 
+  // Mobile: show only current page, Desktop: show full breadcrumb
+  const displayCrumbs = crumbs;
+
   return (
-    <nav className="flex items-center text-sm text-gray-500 dark:text-slate-400" aria-label="Breadcrumb">
-      <ol className="flex items-center gap-2">
-        {crumbs.map((label, index) => (
+    <nav className="flex items-center text-xs md:text-sm text-gray-500 dark:text-slate-400" aria-label="Breadcrumb">
+      {/* Mobile: Only show current page */}
+      <div className="block md:hidden">
+        <span className="font-semibold text-gray-700 dark:text-slate-200 uppercase tracking-wide">
+          {crumbs[crumbs.length - 1]}
+        </span>
+      </div>
+
+      {/* Desktop: Show full breadcrumb */}
+      <ol className="hidden md:flex items-center gap-2">
+        {displayCrumbs.map((label, index) => (
           <li key={label} className="flex items-center gap-2">
             <span
               className={`uppercase tracking-wide ${
-                index === crumbs.length - 1
+                index === displayCrumbs.length - 1
                   ? 'font-semibold text-gray-700 dark:text-slate-200'
                   : 'text-gray-500 dark:text-slate-400'
               }`}
             >
               {label}
             </span>
-            {index < crumbs.length - 1 ? (
+            {index < displayCrumbs.length - 1 ? (
               <ChevronRightIcon className="h-4 w-4" aria-hidden="true" />
             ) : null}
           </li>

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -22,11 +22,13 @@ import sergioFrancoMark from '../assets/sergio-franco-mark.svg';
 interface NavigationProps {
   isCollapsed: boolean;
   onToggleCollapse: () => void;
+  onMobileMenuClose?: () => void;
 }
 
 export const Navigation: React.FC<NavigationProps> = ({
   isCollapsed,
   onToggleCollapse,
+  onMobileMenuClose,
 }) => {
   const { user, logout } = useAuth();
   const { theme, toggleTheme } = useTheme();
@@ -89,6 +91,7 @@ export const Navigation: React.FC<NavigationProps> = ({
       <NavLink
         key={item.id}
         to={item.to}
+        onClick={() => onMobileMenuClose?.()}
         className={({ isActive: linkActive }) => {
           const active = linkActive || fallbackActive;
           return [
@@ -132,7 +135,7 @@ export const Navigation: React.FC<NavigationProps> = ({
 
   return (
     <nav
-      className={`bg-white dark:bg-slate-950 shadow-sm border-r border-gray-200/80 dark:border-slate-800 min-h-screen flex flex-col transition-all duration-300 ${
+      className={`bg-white dark:bg-slate-950 shadow-lg lg:shadow-sm border-r border-gray-200/80 dark:border-slate-800 min-h-[calc(100vh-3.5rem)] lg:min-h-screen flex flex-col transition-all duration-300 ${
         isCollapsed ? 'w-16' : 'w-72'
       }`}
       aria-label="Menu principal"

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -1,10 +1,13 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
+import { Bars3Icon } from '@heroicons/react/24/outline';
 import { Breadcrumbs } from '../Breadcrumbs';
 import { Navigation } from '../Navigation';
+import sergioFrancoMark from '../../assets/sergio-franco-mark.svg';
 
 export const MainLayout: React.FC = () => {
   const [isNavigationCollapsed, setIsNavigationCollapsed] = useState(false);
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const mainContentRef = useRef<HTMLElement>(null);
   const location = useLocation();
 
@@ -12,22 +15,79 @@ export const MainLayout: React.FC = () => {
     mainContentRef.current?.focus();
   }, [location.pathname]);
 
+  // Close mobile menu when location changes
+  useEffect(() => {
+    setIsMobileMenuOpen(false);
+  }, [location.pathname]);
+
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-slate-900 text-slate-900 dark:text-slate-100 flex transition-colors duration-300">
-      <Navigation
-        isCollapsed={isNavigationCollapsed}
-        onToggleCollapse={() => setIsNavigationCollapsed((previous) => !previous)}
-      />
-      <main
-        ref={mainContentRef}
-        className="flex-1 p-6 sm:p-8 lg:p-10 transition-all duration-300"
-        tabIndex={-1}
-      >
-        <div className="flex flex-col gap-6">
-          <Breadcrumbs />
-          <Outlet />
+    <div className="min-h-screen bg-gray-50 dark:bg-slate-900 text-slate-900 dark:text-slate-100 transition-colors duration-300">
+      {/* Mobile Header - Fixed at top */}
+      <header className="lg:hidden fixed top-0 left-0 right-0 z-30 bg-white dark:bg-slate-950 border-b border-gray-200 dark:border-slate-800 px-4 py-3 shadow-sm">
+        <div className="flex items-center justify-between">
+          <button
+            onClick={() => setIsMobileMenuOpen(true)}
+            className="p-2 -ml-2 rounded-md text-gray-600 dark:text-slate-400 hover:bg-gray-100 dark:hover:bg-slate-900 hover:text-gray-900 dark:hover:text-slate-200 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-slate-950"
+            aria-label="Abrir menu"
+            aria-expanded={isMobileMenuOpen}
+          >
+            <Bars3Icon className="h-6 w-6" />
+          </button>
+
+          {/* Logo no center */}
+          <img
+            src={sergioFrancoMark}
+            alt="Sérgio Franco Medicina Diagnóstica"
+            className="h-8 w-8"
+            draggable={false}
+          />
+
+          {/* Spacer for balance */}
+          <div className="w-10" />
         </div>
-      </main>
+      </header>
+
+      {/* Mobile Menu Backdrop */}
+      {isMobileMenuOpen && (
+        <div
+          className="fixed inset-0 bg-black bg-opacity-50 z-40 lg:hidden"
+          onClick={() => setIsMobileMenuOpen(false)}
+          aria-hidden="true"
+        />
+      )}
+
+      {/* Desktop & Mobile Layout */}
+      <div className="flex min-h-screen lg:pt-0 pt-14">
+        {/* Navigation - Desktop sidebar / Mobile drawer */}
+        <div
+          className={`
+            fixed lg:static
+            inset-y-0 left-0 z-50
+            transform lg:transform-none
+            transition-transform duration-300 ease-in-out
+            ${isMobileMenuOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0'}
+            pt-14 lg:pt-0
+          `}
+        >
+          <Navigation
+            isCollapsed={isNavigationCollapsed}
+            onToggleCollapse={() => setIsNavigationCollapsed((previous) => !previous)}
+            onMobileMenuClose={() => setIsMobileMenuOpen(false)}
+          />
+        </div>
+
+        {/* Main Content */}
+        <main
+          ref={mainContentRef}
+          className="flex-1 p-4 md:p-6 lg:p-10 transition-all duration-300 overflow-y-auto"
+          tabIndex={-1}
+        >
+          <div className="flex flex-col gap-4 md:gap-6">
+            <Breadcrumbs />
+            <Outlet />
+          </div>
+        </main>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary

Implement responsive navigation for mobile and tablet devices as Phase 1 of the mobile responsiveness initiative.

### Changes Made

- ✅ Add mobile header with hamburger menu (visible < 1024px)
- ✅ Convert navigation sidebar to drawer on mobile with smooth transitions
- ✅ Add backdrop overlay for mobile drawer with click-to-close
- ✅ Implement menu close on navigation item click
- ✅ Update breadcrumbs to show only current page on mobile
- ✅ Adjust padding for mobile: p-4 md:p-6 lg:p-10
- ✅ Maintain full desktop experience (≥ 1024px)
- ✅ Add smooth transitions and proper focus management

### Files Modified

1. **MainLayout.tsx** (frontend/src/components/layout/)
   - Add mobile header with hamburger button
   - Add isMobileMenuOpen state
   - Add backdrop overlay for mobile drawer
   - Adjust layout for mobile navigation drawer
   - Close menu on route change

2. **Navigation.tsx** (frontend/src/components/)
   - Add onMobileMenuClose prop
   - Close menu on navigation item click
   - Adjust min-height for mobile drawer
   - Add shadow on mobile

3. **Breadcrumbs.tsx** (frontend/src/components/)
   - Hide full breadcrumb on mobile (< md)
   - Show only current page on mobile
   - Show full breadcrumb on desktop

### Test Results

- [x] Mobile layout (375px × 667px) - Hamburger menu appears, responsive ✓
- [x] Tablet layout (768px × 1024px) - Menu transitions properly ✓
- [x] Desktop layout (1440px+) - Full sidebar visible, no mobile header ✓
- [x] Linting - No errors in Phase 1 files ✓

### Notes

This is Phase 1 of the mobile responsiveness initiative. Additional phases will follow:
- Phase 2: Modals & Forms optimization
- Phase 3: Tables & Data Display
- Phase 4: Filters & Search
- And more...

See \`features/planned/mobile-responsiveness.md\` for the complete implementation plan.

🧠 Generated with Claude Code
Co-Authored-By: Claude <noreply@anthropic.com>