### PR TITLE
fix: add ColumnMeta type declaration for className

### DIFF
--- a/frontend/src/types/tanstack-table.d.ts
+++ b/frontend/src/types/tanstack-table.d.ts
@@ -1,0 +1,8 @@
+import '@tanstack/react-table';
+
+declare module '@tanstack/react-table' {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  interface ColumnMeta<TData, TValue> {
+    className?: string;
+  }
+}


### PR DESCRIPTION
## Summary
Fix TypeScript build errors in table components by adding proper type declaration for TanStack Table's `ColumnMeta` interface.

## Problem
Docker build was failing with TypeScript errors:
```
error TS2339: Property 'className' does not exist on type 'ColumnMeta<AppointmentViewModel, unknown>'
error TS2339: Property 'className' does not exist on type 'ColumnMeta<Collector, unknown>'
error TS2339: Property 'className' does not exist on type 'ColumnMeta<Driver, unknown>'
```

These errors occurred in:
- [AppointmentTable.tsx:381,443](src/components/AppointmentTable.tsx#L381)
- [CollectorTable.tsx:222,247](src/components/CollectorTable.tsx#L222)
- [DriverTable.tsx:198,237](src/components/DriverTable.tsx#L198)

## Solution
Created `src/types/tanstack-table.d.ts` with module declaration extending TanStack Table's `ColumnMeta` interface to include `className` property.

```typescript
import '@tanstack/react-table';

declare module '@tanstack/react-table' {
  interface ColumnMeta<TData, TValue> {
    className?: string;
  }
}
```

## Testing
- ✅ TypeScript compilation passes (`npx tsc -b`)
- ✅ No type errors in affected table components
- ✅ Existing functionality preserved

## Impact
- Unblocks Docker builds
- Fixes Phase 3 table components
- No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a TypeScript module augmentation to include an optional `className` on `ColumnMeta` from `@tanstack/react-table`.
> 
> - **Types**:
>   - Add module augmentation in `frontend/src/types/tanstack-table.d.ts` to extend `@tanstack/react-table` `ColumnMeta` with optional `className`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47ff5bd3169c1e0c4e4e460918a1e4f6f6489bbc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->