### PR TITLE
fix: use dev environment for lab deployment secrets

### DIFF
--- a/.github/workflows/deploy-lab.yml
+++ b/.github/workflows/deploy-lab.yml
@@ -12,7 +12,7 @@ jobs:
   deploy:
     name: Deploy to Lab Environment
     runs-on: ubuntu-latest
-    environment: lab
+    environment: dev
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- Change workflow environment from `lab` to `dev` to use existing secrets

## Problem
Deploy action failed with "missing server host" because `lab` environment has no secrets configured.

## Solution
Use `dev` environment which already has SSH_HOST, SSH_USER, SSH_PRIVATE_KEY, and OPENROUTER_API_KEY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)