### PR TITLE
fix: add security-events permission and upgrade codeql to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,9 @@ jobs:
   security-scan:
     name: Security Scanning
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
 
     steps:
     - name: Checkout code
@@ -185,7 +188,7 @@ jobs:
         output: 'trivy-results.sarif'
 
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@v4
       if: always()
       with:
         sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
## Summary
- Add `security-events: write` permission to security-scan job
- Upgrade codeql-action from v3 to v4 (v3 deprecated Dec 2026)

## Problem
SARIF upload failed with "Resource not accessible by integration" due to missing permissions.

## Test plan
- [ ] CI workflow runs without permission errors
- [ ] Trivy results appear in Security tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)